### PR TITLE
v1.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 **/.dockerignore
 **/.env
 **/.git
+**/.github
 **/.gitignore
 **/.project
 **/.settings

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -30,7 +30,7 @@ import twitter
 
 import praw
 
-__version__ = "0.1-alpha"
+__version__ = "1.0"
 
 GENERIC_DATA_LOCK = threading.Lock()
 GAME_DATA_LOCK = threading.Lock()

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -283,8 +283,7 @@ class Bot(object):
                     (
                         True
                         for x in self.commonData[0]["leagueSchedule"]
-                        if x["status"]["abstractGameCode"] != "F"
-                        and x["status"]["codedGameState"] != "D"
+                        if x["status"]["codedGameState"] != "D"
                     ),
                     False,
                 ):
@@ -1483,7 +1482,7 @@ class Bot(object):
             sum(
                 1
                 for k, v in self.activeGames.items()
-                if k not in [0, 'weekly', 'off', 'gameday'] and v.get("postGameThread")
+                if k not in [0, "weekly", "off", "gameday"] and v.get("postGameThread")
             )
             == len(self.activeGames) - 1
         ):
@@ -1497,7 +1496,13 @@ class Bot(object):
             # Check DB (record in pkThreads with gamePk and type='post' and gameDate=today)
             pgq = "select * from {}threads where type='post' and gamePk in ({}) and gameDate = '{}' and deleted=0;".format(
                 self.dbTablePrefix,
-                ",".join([str(x) for x in self.activeGames.keys() if isinstance(x, int) and x > 0 and x != pk]),
+                ",".join(
+                    [
+                        str(x)
+                        for x in self.activeGames.keys()
+                        if isinstance(x, int) and x > 0 and x != pk
+                    ]
+                ),
                 self.today["Y-m-d"],
             )
             pgThread = rbdb.db_qry(pgq, closeAfter=True, logg=self.log)

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -1606,7 +1606,11 @@ class Bot(object):
                 break
             elif update_gameday_thread_until == "Game thread is posted":
                 if next(
-                    (True for k, v in self.activeGames.items() if v.get("gameThread") or v.get("postGameThread")),
+                    (
+                        True
+                        for k, v in self.activeGames.items()
+                        if v.get("gameThread") or v.get("postGameThread")
+                    ),
                     False,
                 ) or next(
                     (
@@ -2665,8 +2669,14 @@ class Bot(object):
 
                 myTeamBatting = (
                     True
-                    if atBat["about"]["halfInning"].lower() == "bottom"
-                    and self.commonData.get(pk, {}).get("homeAway", "") == "home"
+                    if (
+                        atBat["about"]["isTopInning"]
+                        and self.commonData.get(pk, {}).get("homeAway", "") == "away"
+                    )
+                    or (
+                        not atBat["about"]["isTopInning"]
+                        and self.commonData.get(pk, {}).get("homeAway", "") == "home"
+                    )
                     else False
                 )
                 if not processedAtBats.get(str(atBat["atBatIndex"])):

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -1918,6 +1918,13 @@ class Bot(object):
                     )
                 ):
                     # Straight doubleheader game 2 - post time doesn't matter, submit post after game 1 is final
+                    # But wait 5 minutes and update common data to pull in new records
+                    self.log.info(
+                        "Waiting 5 minutes and then proceeding with game thread for straight doubleheader game 2 ({}) because doubleheader game 1 is {}.".format(
+                            pk, otherGame["schedule"]["status"]["detailedState"]
+                        )
+                    )
+                    self.sleep(300)
                     self.log.info(
                         "Proceeding with game thread for straight doubleheader game 2 ({}) because doubleheader game 1 is {}.".format(
                             pk, otherGame["schedule"]["status"]["detailedState"]

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -6221,7 +6221,7 @@ class Bot(object):
                 botStatus["summary"]["text"] += "\n\nGame Day Thread{}.".format(
                     " disabled"
                     if not botStatus["gameDayThread"]["enabled"]
-                    else " failed to post (check log for error)"
+                    else " skipped or failed to post (check log for error)"
                     if not botStatus["gameDayThread"]["posted"]
                     and datetime.strptime(
                         botStatus["gameDayThread"]["postTime"], "%m/%d/%Y %I:%M:%S %p"
@@ -6240,7 +6240,7 @@ class Bot(object):
                 ] += "<br /><br /><strong>Game Day Thread</strong>{}.".format(
                     " disabled."
                     if not botStatus["gameDayThread"]["enabled"]
-                    else " failed to post (check log for error)"
+                    else " skipped or failed to post (check log for error)"
                     if not botStatus["gameDayThread"]["posted"]
                     and datetime.strptime(
                         botStatus["gameDayThread"]["postTime"], "%m/%d/%Y %I:%M:%S %p"
@@ -6265,7 +6265,7 @@ class Bot(object):
                         botStatus["seasonState"].startswith("off")
                         or botStatus["seasonState"] == "post:out"
                     )
-                    else " failed to post (check log for error)"
+                    else " skipped or failed to post (check log for error)"
                     if not botStatus["gameDayThread"]["posted"]
                     and datetime.strptime(
                         botStatus["gameDayThread"]["postTime"], "%m/%d/%Y %I:%M:%S %p"
@@ -6289,6 +6289,9 @@ class Bot(object):
                                 k,
                                 " disabled."
                                 if not v["threads"]["game"]["enabled"]
+                                else " skipped"
+                                if v["threads"]["game"].get("postTime", "") == ""
+                                and not v["threads"]["game"]["posted"]
                                 else " failed to post (check log for error)"
                                 if not v["threads"]["game"]["posted"]
                                 and datetime.strptime(
@@ -6324,6 +6327,9 @@ class Bot(object):
                                 k,
                                 " disabled."
                                 if not v["threads"]["game"]["enabled"]
+                                else " skipped"
+                                if v["threads"]["game"].get("postTime", "") == ""
+                                and not v["threads"]["game"]["posted"]
                                 else " failed to post (check log for error)"
                                 if not v["threads"]["game"]["posted"]
                                 and datetime.strptime(
@@ -6359,6 +6365,9 @@ class Bot(object):
                                 k,
                                 " disabled."
                                 if not v["threads"]["game"]["enabled"]
+                                else " skipped"
+                                if v["threads"]["game"].get("postTime", "") == ""
+                                and not v["threads"]["game"]["posted"]
                                 else " failed to post (check log for error)"
                                 if not v["threads"]["game"]["posted"]
                                 and datetime.strptime(

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -1606,12 +1606,24 @@ class Bot(object):
                 break
             elif update_gameday_thread_until == "Game thread is posted":
                 if next(
-                    (True for k, v in self.activeGames.items() if v.get("gameThread")),
+                    (True for k, v in self.activeGames.items() if v.get("gameThread") or v.get("postGameThread")),
+                    False,
+                ) or next(
+                    (
+                        True
+                        for k, v in self.commonData.items()
+                        if k != 0
+                        and (
+                            v["schedule"]["status"]["abstractGameCode"] == "F"
+                            or v["schedule"]["status"]["codedGameState"]
+                            in ["C", "D", "U", "T"]
+                        )
+                    ),
                     False,
                 ):
                     # Game thread is posted
                     self.log.info(
-                        "At least one game thread is posted. Stopping game day thread update loop per UPDATE_UNTIL setting."
+                        "At least one game thread is posted (or post game thread is posted, or game is final). Stopping game day thread update loop per UPDATE_UNTIL setting."
                     )
                     self.activeGames[pk].update({"STOP_FLAG": True})
                     break

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -2719,16 +2719,16 @@ class Bot(object):
                         )
                         or (
                             "scoring_play" in myTeamBattingEvents
-                            and atBat["playEvents"][actionIndex]["details"][
+                            and atBat["playEvents"][actionIndex]["details"].get(
                                 "isScoringPlay"
-                            ]
+                            )
                             and myTeamBatting
                         )
                         or (
                             "scoring_play" in myTeamPitchingEvents
-                            and atBat["playEvents"][actionIndex]["details"][
+                            and atBat["playEvents"][actionIndex]["details"].get(
                                 "isScoringPlay"
-                            ]
+                            )
                             and not myTeamBatting
                         )
                     ):
@@ -2743,9 +2743,9 @@ class Bot(object):
                                     .replace(" ", "_"),
                                 ),
                                 "/scoring_play"
-                                if atBat["playEvents"][actionIndex]["details"][
+                                if atBat["playEvents"][actionIndex]["details"].get(
                                     "isScoringPlay"
-                                ]
+                                )
                                 else "",
                                 myTeamBatting,
                             )
@@ -2892,12 +2892,12 @@ class Bot(object):
                         )
                         or (
                             "scoring_play" in myTeamBattingEvents
-                            and atBat["about"]["isScoringPlay"]
+                            and atBat["about"].get("isScoringPlay")
                             and myTeamBatting
                         )
                         or (
                             "scoring_play" in myTeamPitchingEvents
-                            and atBat["about"]["isScoringPlay"]
+                            and atBat["about"].get("isScoringPlay")
                             and not myTeamBatting
                         )
                     ):
@@ -2912,7 +2912,7 @@ class Bot(object):
                                     .replace(" ", "_"),
                                 ),
                                 "/scoring_play"
-                                if atBat["about"]["isScoringPlay"]
+                                if atBat["about"].get("isScoringPlay")
                                 else "",
                                 myTeamBatting,
                             )
@@ -2950,7 +2950,7 @@ class Bot(object):
                                     atBatIndex=atBat["atBatIndex"],
                                     actionIndex=None,
                                     isScoringPlay=1
-                                    if atBat["about"]["isScoringPlay"]
+                                    if atBat["about"].get("isScoringPlay")
                                     else 0,
                                     eventType=atBat["result"].get(
                                         "eventType",
@@ -4898,7 +4898,12 @@ class Bot(object):
                 if q[:-1] == ")":
                     q += ","
                 q += " ({}, '{}', '{}', '{}', {}, {})".format(
-                    k, threadType, self.today["Y-m-d"], threadId, time.time(), time.time()
+                    k,
+                    threadType,
+                    self.today["Y-m-d"],
+                    threadId,
+                    time.time(),
+                    time.time(),
                 )
         else:
             q += " ({}, '{}', '{}', '{}', {}, {})".format(
@@ -4908,9 +4913,7 @@ class Bot(object):
         q += ";"
         i = rbdb.db_qry(q, commit=True, closeAfter=True, logg=self.log)
         if isinstance(i, str):
-            self.log.error(
-                "Error inserting thread into database: {}".format(i)
-            )
+            self.log.error("Error inserting thread into database: {}".format(i))
             return False
         else:
             return True

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -1983,7 +1983,7 @@ class Bot(object):
                             pk,
                             self.activeGames[pk]["postTime"],
                             " (will hold past post time until doubleheader game 1 ({}) is final)".format(
-                                otherGame["gamePk"]
+                                otherGame["schedule"]["gamePk"]
                             )
                             if self.commonData[pk]["schedule"]["doubleHeader"] != "N"
                             and self.commonData[pk]["schedule"]["gameNumber"] != 1
@@ -2001,7 +2001,7 @@ class Bot(object):
                 ):
                     self.log.info(
                         "Game {} thread post time has passed, but holding until doubleheader game 1 ({}) is final. Sleeping for 5 minutes....".format(
-                            pk, otherGame["gamePk"]
+                            pk, otherGame["schedule"]["gamePk"]
                         )
                     )
                     self.sleep(300)

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -100,7 +100,7 @@ class Bot(object):
 
         # Start a scheduled task to update self.bot.detailedState every minute
         self.SCHEDULER.add_job(
-            self.bot_state, "interval", name="statusUpdateTask", minutes=1
+            self.bot_state, "interval", name=f"bot-{self.bot.id}-statusUpdateTask", minutes=1
         )
 
         settings_date = datetime.today().strftime("%Y-%m-%d")

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -1206,10 +1206,6 @@ class Bot(object):
             )
             skipFlag = True
 
-        # Mark off day thread as stale so it will be unstickied tomorrow
-        if offDayThread:
-            self.staleThreads.append(offDayThread)
-
         while (
             not self.activeGames["off"]["STOP_FLAG"]
             and redball.SIGNAL is None
@@ -1339,6 +1335,10 @@ class Bot(object):
 
         if redball.SIGNAL is not None or self.bot.STOP:
             self.log.debug("Caught a stop signal...")
+
+        # Mark off day thread as stale so it will be unstickied tomorrow
+        if offDayThread:
+            self.staleThreads.append(offDayThread)
 
         self.log.debug("Ending off day update thread...")
         return

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -30,7 +30,7 @@ import twitter
 
 import praw
 
-__version__ = "0.0.7"
+__version__ = "0.1-alpha"
 
 
 def run(bot, settings):

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -1912,8 +1912,13 @@ class Bot(object):
                     self.commonData[pk]["schedule"]["doubleHeader"] == "Y"
                     and self.commonData[pk]["schedule"]["gameNumber"] == 2
                     and (
-                        otherGame["schedule"]["status"]["abstractGameCode"] == "F"
-                        or otherGame["schedule"]["status"]["codedGameState"]
+                        self.commonData[otherGame["schedule"]["gamePk"]]["schedule"][
+                            "status"
+                        ]["abstractGameCode"]
+                        == "F"
+                        or self.commonData[otherGame["schedule"]["gamePk"]]["schedule"][
+                            "status"
+                        ]["codedGameState"]
                         in ["C", "D", "U", "T"]
                     )
                 ):
@@ -1921,13 +1926,19 @@ class Bot(object):
                     # But wait 5 minutes and update common data to pull in new records
                     self.log.info(
                         "Waiting 5 minutes and then proceeding with game thread for straight doubleheader game 2 ({}) because doubleheader game 1 is {}.".format(
-                            pk, otherGame["schedule"]["status"]["detailedState"]
+                            pk,
+                            self.commonData[otherGame["schedule"]["gamePk"]][
+                                "schedule"
+                            ]["status"]["detailedState"],
                         )
                     )
                     self.sleep(300)
                     self.log.info(
                         "Proceeding with game thread for straight doubleheader game 2 ({}) because doubleheader game 1 is {}.".format(
-                            pk, otherGame["schedule"]["status"]["detailedState"]
+                            pk,
+                            self.commonData[otherGame["schedule"]["gamePk"]][
+                                "schedule"
+                            ]["status"]["detailedState"],
                         )
                     )
                     break
@@ -1936,15 +1947,23 @@ class Bot(object):
                     and self.commonData[pk]["schedule"]["doubleHeader"] == "S"
                     and self.commonData[pk]["schedule"]["gameNumber"] == 2
                     and (
-                        otherGame["schedule"]["status"]["abstractGameCode"] == "F"
-                        or otherGame["schedule"]["status"]["codedGameState"]
+                        self.commonData[otherGame["schedule"]["gamePk"]]["schedule"][
+                            "status"
+                        ]["abstractGameCode"]
+                        == "F"
+                        or self.commonData[otherGame["schedule"]["gamePk"]]["schedule"][
+                            "status"
+                        ]["codedGameState"]
                         in ["C", "D", "U", "T"]
                     )
                 ):
                     # Split doubleheader game 2 - honor post time, but only after game 1 is final
                     self.log.info(
                         "Proceeding with game thread for split doubleheader game 2 ({}) because doubleheader game 1 is {} and post time is reached.".format(
-                            pk, otherGame["schedule"]["status"]["detailedState"]
+                            pk,
+                            self.commonData[otherGame["schedule"]["gamePk"]][
+                                "schedule"
+                            ]["status"]["detailedState"],
                         )
                     )
                     break
@@ -1979,8 +1998,12 @@ class Bot(object):
                     and self.commonData[pk]["schedule"]["gameNumber"] != 1
                 ):
                     self.log.info(
-                        "Game {} thread post time has passed, but holding until doubleheader game 1 ({}) is final. Sleeping for 5 minutes....".format(
-                            pk, otherGame["schedule"]["gamePk"]
+                        "Game {} thread post time has passed, but holding until doubleheader game 1 ({}) is final (currently {}). Sleeping for 5 minutes....".format(
+                            pk,
+                            otherGame["schedule"]["gamePk"],
+                            self.commonData[otherGame["schedule"]["gamePk"]][
+                                "schedule"
+                            ]["status"]["detailedState"],
                         )
                     )
                     self.sleep(300)

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -1855,7 +1855,7 @@ class Bot(object):
                 )
                 self.log.debug(
                     "Other Game ({}) abstractGameCode: {} - codedGameState: {}".format(
-                        otherGame["gamePk"],
+                        otherGame["schedule"]["gamePk"],
                         otherGame["schedule"]["status"]["abstractGameCode"],
                         otherGame["schedule"]["status"]["codedGameState"],
                     )

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -4888,8 +4888,8 @@ class Bot(object):
         else:
             return True
 
-    def insert_thread_to_db(self, pk, threadId, type):
-        # pk = gamePk (or list of gamePks), threadId = thread object returned from Reddit (OFF+date for off day threads), type = ['gameday', 'game', 'post', 'off', 'weekly']
+    def insert_thread_to_db(self, pk, threadId, threadType):
+        # pk = gamePk (or list of gamePks), threadId = thread object returned from Reddit (OFF+date for off day threads), threadType = ['gameday', 'game', 'post', 'off', 'weekly']
         q = "insert or ignore into {}threads (gamePk, type, gameDate, id, dateCreated, dateUpdated) values".format(
             self.dbTablePrefix
         )
@@ -4898,18 +4898,18 @@ class Bot(object):
                 if q[:-1] == ")":
                     q += ","
                 q += " ({}, '{}', '{}', '{}', {}, {})".format(
-                    k, type, self.today["Y-m-d"], threadId, time.time(), time.time()
+                    k, threadType, self.today["Y-m-d"], threadId, time.time(), time.time()
                 )
         else:
             q += " ({}, '{}', '{}', '{}', {}, {})".format(
-                pk, type, self.today["Y-m-d"], threadId, time.time(), time.time()
+                pk, threadType, self.today["Y-m-d"], threadId, time.time(), time.time()
             )
 
         q += ";"
         i = rbdb.db_qry(q, commit=True, closeAfter=True, logg=self.log)
         if isinstance(i, str):
             self.log.error(
-                "Error inserting post game thread into database: {}".format(i)
+                "Error inserting thread into database: {}".format(i)
             )
             return False
         else:

--- a/bots/game_threads/__init__.py
+++ b/bots/game_threads/__init__.py
@@ -100,7 +100,10 @@ class Bot(object):
 
         # Start a scheduled task to update self.bot.detailedState every minute
         self.SCHEDULER.add_job(
-            self.bot_state, "interval", name=f"bot-{self.bot.id}-statusUpdateTask", minutes=1
+            self.bot_state,
+            "interval",
+            name=f"bot-{self.bot.id}-statusUpdateTask",
+            minutes=1,
         )
 
         settings_date = datetime.today().strftime("%Y-%m-%d")
@@ -3840,7 +3843,8 @@ class Bot(object):
                                     }
                                     for k, v in self.commonData.items()
                                     if k not in [0, "weekly", "off", "gameday"]
-                                    and v.get("schedule", {}).get("gamePk") != x["gamePk"]
+                                    and v.get("schedule", {}).get("gamePk")
+                                    != x["gamePk"]
                                     and v.get("schedule", {}).get("doubleHeader") == "Y"
                                     and v.get("schedule", {}).get("gameNumber") == 1
                                     and v.get("schedule", {})
@@ -3869,7 +3873,10 @@ class Bot(object):
                                 # Check league schedule
                                 otherGame = next(
                                     (
-                                        {"gamePk": v["gamePk"], "gameDate": v["gameDate"]}
+                                        {
+                                            "gamePk": v["gamePk"],
+                                            "gameDate": v["gameDate"],
+                                        }
                                         for v in games
                                         if v.get("gamePk") != x["gamePk"]
                                         and v.get("doubleHeader") == "Y"

--- a/bots/game_threads/templates/comment_body.mako
+++ b/bots/game_threads/templates/comment_body.mako
@@ -55,7 +55,11 @@ ${atBat['result']['description']}
     % if len(atBat['pitchIndex']) > 0 and atBat['playEvents'][atBat['pitchIndex'][-1]].get('pitchData'):
     ## Event has pitch data
 
-Pitch from ${atBat['matchup']['pitcher']['fullName']}: ${atBat['playEvents'][atBat['pitchIndex'][-1]].get('preCount',{}).get('balls','0')}-${atBat['playEvents'][atBat['pitchIndex'][-1]].get('preCount',{}).get('strikes','0')} ${atBat['playEvents'][atBat['pitchIndex'][-1]].get('details',{}).get('type',{}).get('description','Unknown pitch type')} @ ${atBat['playEvents'][atBat['pitchIndex'][-1]].get('pitchData',{}).get('startSpeed','-')} mph
+Pitch from ${atBat['matchup']['pitcher']['fullName']}: \
+% if atBat['playEvents'][atBat['pitchIndex'][-1]].get('preCount'):  # preCount is no longer included in the data, so don't list pitch count as 0-0
+${atBat['playEvents'][atBat['pitchIndex'][-1]].get('preCount',{}).get('balls','0')}-${atBat['playEvents'][atBat['pitchIndex'][-1]].get('preCount',{}).get('strikes','0')} \
+% endif
+${atBat['playEvents'][atBat['pitchIndex'][-1]].get('details',{}).get('type',{}).get('description','Unknown pitch type')} @ ${atBat['playEvents'][atBat['pitchIndex'][-1]].get('pitchData',{}).get('startSpeed','-')} mph
     % endif
     % if len(atBat['pitchIndex']) > 0 and atBat['playEvents'][atBat['pitchIndex'][-1]].get('hitData'):
     ## Event has hit data

--- a/bots/game_threads/templates/comment_body.mako
+++ b/bots/game_threads/templates/comment_body.mako
@@ -67,7 +67,7 @@ Hit by ${atBat['matchup']['batter']['fullName']}: Launched ${atBat['playEvents']
 
 ${atBat['about']['halfInning'].capitalize()} ${atBat['about']['inning']} - \
 ${max(atBat['result']['homeScore'], atBat['result']['awayScore'])}-${min(atBat['result']['homeScore'], atBat['result']['awayScore'])} 
-${'TIE' if atBat['result']['homeScore'] == atBat['result']['awayScore'] else data[0]['myTeam']['teamName'] if atBat['result']['homeScore'] > atBat['result']['awayScore'] and data[gamePk]['homeAway']=='home' else data[gamePk]['oppTeam']['teamName']}
+${'TIE' if atBat['result']['homeScore'] == atBat['result']['awayScore'] else data[0]['myTeam']['teamName'] if ((atBat['result']['homeScore'] > atBat['result']['awayScore'] and data[gamePk]['homeAway']=='home') or (atBat['result']['awayScore'] > atBat['result']['homeScore'] and data[gamePk]['homeAway']=='away')) else data[gamePk]['oppTeam']['teamName']}
     % endif
     % if settings.get("Comments", {}).get(("MYTEAM_BATTING_FOOTER_" if myTeamBatting else "MYTEAM_PITCHING_FOOTER_") + eventType.upper()):
     ## Footer is defined for this event

--- a/bots/game_threads/templates/game_info.mako
+++ b/bots/game_threads/templates/game_info.mako
@@ -1,8 +1,10 @@
 <%page args="gamePk" />
 ${'###'}Links & Info
 ## Venue & weather
-% if data[gamePk]['schedule'].get('weather') and len(data[gamePk]['schedule']['weather']):
-* Current conditions at ${data[gamePk]['schedule']['venue']['name']}: ${data[gamePk]['schedule']['weather']['temp']+'&#176;F' if data[gamePk]['schedule']['weather'].get('temp') else ''} ${'- ' + data[gamePk]['schedule']['weather']['condition'] if data[gamePk]['schedule']['weather'].get('condition') else ''} ${'- Wind ' + data[gamePk]['schedule']['weather']['wind'] if data[gamePk]['schedule']['weather'].get('wind') else ''}
+% if data[gamePk]['schedule'].get('weather') and len(data[gamePk]['schedule']['weather']) and (data[gamePk]['schedule']['weather'].get('temp') or data[gamePk]['schedule']['weather'].get('condition') or data[gamePk]['schedule']['weather'].get('wind') != 'null mph, null'):
+* Current conditions at ${data[gamePk]['schedule']['venue']['name']}: ${data[gamePk]['schedule']['weather']['temp']+'&#176;F' if data[gamePk]['schedule']['weather'].get('temp') else ''} ${'- ' + data[gamePk]['schedule']['weather']['condition'] if data[gamePk]['schedule']['weather'].get('condition') else ''} ${'- Wind ' + data[gamePk]['schedule']['weather']['wind'] if data[gamePk]['schedule']['weather'].get('wind')  != 'null mph, null' else ''}
+% else:
+* Venue: ${data[gamePk]['schedule']['venue']['name']}
 % endif
 <%
     awayTv = [x for x in data[gamePk]['schedule'].get('broadcasts', []) if x.get('type')=='TV' and x.get('homeAway')=='away' and not x.get('isNational',False)]

--- a/bots/game_threads/templates/game_thread.mako
+++ b/bots/game_threads/templates/game_thread.mako
@@ -11,8 +11,10 @@ ${'###'}Game Status: ${data[gamePk]['schedule']['status']['detailedState']} \
 due to ${data[gamePk]['schedule']['status']['reason']} \
 % endif
 % if data[gamePk]['gameTime']['utc'] > datetime.utcnow().replace(tzinfo=pytz.utc) and data[gamePk]['schedule']['status']['abstractGameCode'] != 'F':
+%if not (data[gamePk]['schedule']['doubleHeader'] == 'Y' and data[gamePk]['schedule']['gameNumber'] == 2):
 - First Pitch is scheduled for ${data[gamePk]['gameTime']['myTeam'].strftime('%I:%M %p %Z')}
 
+% endif
 % elif (data[gamePk]['schedule']['status']['abstractGameCode'] == 'L' and data[gamePk]['schedule']['status']['statusCode'] != 'PW') or (data[gamePk]['schedule']['status']['abstractGameCode'] == 'F' and data[gamePk]['schedule']['status']['codedGameState'] not in ['C','D']):
 ## Game status is live and not warmup, so include info about inning and outs on the game status line
 - <%include file="score.mako" /> \

--- a/bots/game_threads/templates/game_title.mako
+++ b/bots/game_threads/templates/game_title.mako
@@ -1,6 +1,8 @@
 <%
     from datetime import datetime
     prefix = settings.get("Game Thread", {}).get("TITLE_PREFIX","Game Thread:")
+    dateFormat = settings.get("Game Thread", {}).get("DATE_FORMAT","%a, %b %d @ %I:%M %p %Z")
+    dhDateFormat = settings.get("Game Thread", {}).get("DATE_FORMAT_DH","%a, %b %d")
 %>\
 ${prefix + (" " if len(prefix) and not prefix.endswith(" ") else "")}\
 %if data[gamePk]['schedule'].get('seriesDescription') and data[gamePk]['schedule'].get('gameType') not in ['R','I','S','E']:
@@ -10,9 +12,9 @@ ${'Game ' + str(data[gamePk]['schedule']['seriesGameNumber']) + ' - ' if data[ga
 ${data[gamePk]['schedule']['teams']['away']['team']['teamName']} (${data[gamePk]['schedule']['teams']['away']['leagueRecord']['wins']}-${data[gamePk]['schedule']['teams']['away']['leagueRecord']['losses']})\
  @ ${data[gamePk]['schedule']['teams']['home']['team']['teamName']} (${data[gamePk]['schedule']['teams']['home']['leagueRecord']['wins']}-${data[gamePk]['schedule']['teams']['home']['leagueRecord']['losses']})\
 %if data[gamePk]['schedule']['doubleHeader'] == 'Y' and data[gamePk]['schedule']['gameNumber'] == 2:
- - ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d')} - Doubleheader Game 2
+ - ${data[gamePk]['gameTime']['myTeam'].strftime(dhDateFormat)} - Doubleheader Game 2
 %else:
- - ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d @ %I:%M %p %Z')}
+ - ${data[gamePk]['gameTime']['myTeam'].strftime(dateFormat)}
 %endif
 %if data[gamePk]['schedule']['doubleHeader'] == 'S':
  - Doubleheader Game ${data[gamePk]['schedule']['gameNumber']}

--- a/bots/game_threads/templates/game_title.mako
+++ b/bots/game_threads/templates/game_title.mako
@@ -9,4 +9,11 @@ ${'Game ' + str(data[gamePk]['schedule']['seriesGameNumber']) + ' - ' if data[ga
 %endif
 ${data[gamePk]['schedule']['teams']['away']['team']['teamName']} (${data[gamePk]['schedule']['teams']['away']['leagueRecord']['wins']}-${data[gamePk]['schedule']['teams']['away']['leagueRecord']['losses']})\
  @ ${data[gamePk]['schedule']['teams']['home']['team']['teamName']} (${data[gamePk]['schedule']['teams']['home']['leagueRecord']['wins']}-${data[gamePk]['schedule']['teams']['home']['leagueRecord']['losses']})\
+%if data[gamePk]['schedule']['doubleHeader'] == 'Y' and data[gamePk]['schedule']['gameNumber'] == 2:
+ - ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d')} - Doubleheader Game 2
+%else:
  - ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d @ %I:%M %p %Z')}
+%endif
+%if data[gamePk]['schedule']['doubleHeader'] == 'S':
+ - Doubleheader Game ${data[gamePk]['schedule']['gameNumber']}
+%endif

--- a/bots/game_threads/templates/gameday_thread.mako
+++ b/bots/game_threads/templates/gameday_thread.mako
@@ -8,6 +8,12 @@ ${'###'}\
 % endif\
 <%include file="matchup.mako" args="gamePk=pk,dateFormat='%I:%M %p %Z'" />
 
+## Game status: show detailed state and then list first pitch time if game hasn't started yet and isn't final
+${'###'}Game Status: ${data[pk]['schedule']['status']['detailedState']} \
+% if data[pk]['schedule']['status'].get('reason') and len(data[pk]['schedule']['status']['reason']) > 0 and data[pk]['schedule']['status']['reason'] not in data[pk]['schedule']['status']['detailedState']:
+due to ${data[pk]['schedule']['status']['reason']} \
+% endif
+
 ## Broadcasts, gameday link, (strikezone map commented out since it doesn't seem to have data), (game notes commented out due to new press pass requirement)
 <%include file="game_info.mako" args="gamePk=pk" />
 

--- a/bots/game_threads/templates/gameday_title.mako
+++ b/bots/game_threads/templates/gameday_title.mako
@@ -1,5 +1,6 @@
 <%
     from datetime import datetime 
     prefix = settings.get("Game Day Thread", {}).get("TITLE_PREFIX","Game Day Thread")
+    dateFormat = settings.get("Game Day Thread", {}).get("DATE_FORMAT","%A, %B %d")
 %>\
-${data[0]['myTeam']['teamName']} ${prefix + (" " if len(prefix) and not prefix.endswith(" ") else "")}- ${datetime.strptime(data[0]['today']['Ymd'],'%Y%m%d').strftime('%A, %B %d')}
+${data[0]['myTeam']['teamName']} ${prefix + (" " if len(prefix) and not prefix.endswith(" ") else "")}- ${datetime.strptime(data[0]['today']['Ymd'],'%Y%m%d').strftime(dateFormat)}

--- a/bots/game_threads/templates/linescore.mako
+++ b/bots/game_threads/templates/linescore.mako
@@ -8,11 +8,8 @@
     away = []
     for i in data[gamePk]['schedule']['linescore']['innings']:
         header_row.append(str(i['num']))
-        away.append(str(i['away'].get('runs',0)))
-        if data[gamePk]['schedule']['linescore'].get('isTopInning'):
-            home.append(str(i['home'].get('runs','')))
-        else:
-            home.append(str(i['home'].get('runs',0)))
+        away.append(str(i['away'].get('runs','')))
+        home.append(str(i['home'].get('runs','')))
 
     if len(data[gamePk]['schedule']['linescore']['innings']) < 9:
         for i in range(len(data[gamePk]['schedule']['linescore']['innings'])+1, 10):

--- a/bots/game_threads/templates/linescore.mako
+++ b/bots/game_threads/templates/linescore.mako
@@ -9,7 +9,10 @@
     for i in data[gamePk]['schedule']['linescore']['innings']:
         header_row.append(str(i['num']))
         away.append(str(i['away'].get('runs',0)))
-        home.append(str(i['home'].get('runs',0)))
+        if data[gamePk]['schedule']['linescore'].get('isTopInning'):
+            home.append(str(i['home'].get('runs','')))
+        else:
+            home.append(str(i['home'].get('runs',0)))
 
     if len(data[gamePk]['schedule']['linescore']['innings']) < 9:
         for i in range(len(data[gamePk]['schedule']['linescore']['innings'])+1, 10):

--- a/bots/game_threads/templates/matchup.mako
+++ b/bots/game_threads/templates/matchup.mako
@@ -1,3 +1,11 @@
 <%page args="gamePk,dateFormat='%a, %b %d @ %I:%M %p %Z'" />\
 ## Matchup header: Team names with links to team subs and matchup image, followed by game date
-[${data[gamePk]['schedule']['teams']['away']['team']['teamName']}](${data[0]['teamSubs'].get(data[gamePk]['schedule']['teams']['away']['team']['id'], data[0]['teamSubs'][0])}) [@](http://mlb.mlb.com/images/2017_ipad/684/${data[gamePk]['schedule']['teams']['away']['team']['fileCode'] + data[gamePk]['schedule']['teams']['home']['team']['fileCode']}_684.jpg) [${data[gamePk]['schedule']['teams']['home']['team']['teamName']}](${data[0]['teamSubs'].get(data[gamePk]['schedule']['teams']['home']['team']['id'], data[0]['teamSubs'][0])}) - ${data[gamePk]['gameTime']['myTeam'].strftime(dateFormat)}
+[${data[gamePk]['schedule']['teams']['away']['team']['teamName']}](${data[0]['teamSubs'].get(data[gamePk]['schedule']['teams']['away']['team']['id'], data[0]['teamSubs'][0])}) [@](http://mlb.mlb.com/images/2017_ipad/684/${data[gamePk]['schedule']['teams']['away']['team']['fileCode'] + data[gamePk]['schedule']['teams']['home']['team']['fileCode']}_684.jpg) [${data[gamePk]['schedule']['teams']['home']['team']['teamName']}](${data[0]['teamSubs'].get(data[gamePk]['schedule']['teams']['home']['team']['id'], data[0]['teamSubs'][0])}) \
+%if data[gamePk]['schedule']['doubleHeader'] == 'Y' and data[gamePk]['schedule']['gameNumber'] == 2:
+- ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d')} - Doubleheader Game 2
+%else:
+- ${data[gamePk]['gameTime']['myTeam'].strftime(dateFormat)} \
+%endif
+%if data[gamePk]['schedule']['doubleHeader'] == 'S':
+- Doubleheader Game ${data[gamePk]['schedule']['gameNumber']}
+%endif

--- a/bots/game_threads/templates/off_title.mako
+++ b/bots/game_threads/templates/off_title.mako
@@ -1,9 +1,10 @@
 <%
     from datetime import datetime
-    prefix = settings.get("Off Day Thread", {}).get("TITLE_PREFIX","Off Day Thread") 
+    prefix = settings.get("Off Day Thread", {}).get("TITLE_PREFIX","Off Day Thread")
+    dateFormat = settings.get("Off Day Thread", {}).get("DATE_FORMAT","%A, %B %d")
 %>\
 ${data[0]['myTeam']['teamName']} \
 ${prefix if data[0]['myTeam']['seasonState'] in ['pre','regular','post:in'] else ''}\
 ${'Postseason Discussion Thread' if data[0]['myTeam']['seasonState'] == 'post:out' else ''}\
 ${'Offseason Discussion Thread' if data[0]['myTeam']['seasonState'].startswith('off') else ''}\
- - ${datetime.strptime(data[0]['today']['Ymd'],'%Y%m%d').strftime('%A, %B %d')}
+ - ${datetime.strptime(data[0]['today']['Ymd'],'%Y%m%d').strftime(dateFormat)}

--- a/bots/game_threads/templates/post_title.mako
+++ b/bots/game_threads/templates/post_title.mako
@@ -40,4 +40,11 @@ ${data[0]['myTeam']['teamName']} Post Game Thread\
 % endif
 % endif
 \
- - ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d @ %I:%M %p %Z')}
+%if data[gamePk]['schedule']['doubleHeader'] == 'Y' and data[gamePk]['schedule']['gameNumber'] == 2:
+ - ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d')} - Doubleheader Game 2
+%else:
+ - ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d @ %I:%M %p %Z')}\
+%endif
+%if data[gamePk]['schedule']['doubleHeader'] == 'S':
+ - Doubleheader Game ${data[gamePk]['schedule']['gameNumber']}
+%endif

--- a/bots/game_threads/templates/post_title.mako
+++ b/bots/game_threads/templates/post_title.mako
@@ -1,6 +1,8 @@
 <%
     from datetime import datetime 
     prefix = settings.get("Post Game Thread", {}).get("TITLE_PREFIX","")
+    dateFormat = settings.get("Post Game Thread", {}).get("DATE_FORMAT","%a, %b %d @ %I:%M %p %Z")
+    dhDateFormat = settings.get("Post Game Thread", {}).get("DATE_FORMAT_DH","%a, %b %d")
 %>\
 ${prefix + (" " if len(prefix) and not prefix.endswith(" ") else "")}\
 % if data[gamePk]['schedule'].get('seriesDescription') and data[gamePk]['schedule'].get('gameType') not in ['R','I','S','E']:
@@ -11,28 +13,28 @@ ${' Game ' + str(data[gamePk]['schedule']['seriesGameNumber']) if data[gamePk]['
 \
 % if data[gamePk]['schedule']['status']['codedGameState'] in ['U','T','C','D']:
 ## Exception Status (codedGameState - Suspended: U, T; Cancelled: C, Postponed: D)
-The ${data[0]['myTeam']['teamName']} Game is ${data[gamePk]['schedule']['status']['detailedState']}\
+${settings.get("Post Game Thread", {}).get("TITLE_PREFIX_EXCEPTION","")}The ${data[0]['myTeam']['teamName']} Game is ${data[gamePk]['schedule']['status']['detailedState']}\
 % else:
 % if data[gamePk]['schedule']['teams']['home']['score'] == data[gamePk]['schedule']['teams']['away']['score']:
 ## Tie
-The ${data[0]['myTeam']['teamName']} tied the ${data[gamePk]['oppTeam']['teamName']} with a score of ${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}-${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}\
+${settings.get("Post Game Thread", {}).get("TITLE_PREFIX_TIE","")}The ${data[0]['myTeam']['teamName']} tied the ${data[gamePk]['oppTeam']['teamName']} with a score of ${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}-${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}\
 % elif data[gamePk]['schedule']['teams']['home']['score'] > data[gamePk]['schedule']['teams']['away']['score']:
 ## Home Team Won
 % if data[gamePk]['homeAway'] == 'home':
 ## Home Win
-The ${data[0]['myTeam']['teamName']} defeated the ${data[gamePk]['oppTeam']['teamName']} by a score of ${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}-${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}\
+${settings.get("Post Game Thread", {}).get("TITLE_PREFIX_HOME_WIN","")}The ${data[0]['myTeam']['teamName']} defeated the ${data[gamePk]['oppTeam']['teamName']} by a score of ${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}-${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}\
 % else:
 ## Home Loss
-The ${data[0]['myTeam']['teamName']} fell to the ${data[gamePk]['oppTeam']['teamName']} by a score of ${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}-${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}\
+${settings.get("Post Game Thread", {}).get("TITLE_PREFIX_HOME_LOSS","")}The ${data[0]['myTeam']['teamName']} fell to the ${data[gamePk]['oppTeam']['teamName']} by a score of ${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}-${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}\
 % endif
 % elif data[gamePk]['schedule']['teams']['away']['score'] > data[gamePk]['schedule']['teams']['home']['score']:
 ## Away Team Won
 % if data[gamePk]['homeAway'] == 'away':
 ## Road Win
-The ${data[0]['myTeam']['teamName']} defeated the ${data[gamePk]['oppTeam']['teamName']} by a score of ${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}-${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}\
+${settings.get("Post Game Thread", {}).get("TITLE_PREFIX_ROAD_WIN","")}The ${data[0]['myTeam']['teamName']} defeated the ${data[gamePk]['oppTeam']['teamName']} by a score of ${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}-${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}\
 % else:
 ## Road Loss
-The ${data[0]['myTeam']['teamName']} fell to the ${data[gamePk]['oppTeam']['teamName']} by a score of ${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}-${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}\
+${settings.get("Post Game Thread", {}).get("TITLE_PREFIX_ROAD_LOSS","")}The ${data[0]['myTeam']['teamName']} fell to the ${data[gamePk]['oppTeam']['teamName']} by a score of ${data[gamePk]['schedule']['teams']['home' if data[gamePk]['homeAway']=='away' else 'away']['score']}-${data[gamePk]['schedule']['teams'][data[gamePk]['homeAway']]['score']}\
 % endif
 % else:
 ## Unknown game state, use generic <TeamName> Post Game Thread title
@@ -41,9 +43,9 @@ ${data[0]['myTeam']['teamName']} Post Game Thread\
 % endif
 \
 %if data[gamePk]['schedule']['doubleHeader'] == 'Y' and data[gamePk]['schedule']['gameNumber'] == 2:
- - ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d')} - Doubleheader Game 2
+ - ${data[gamePk]['gameTime']['myTeam'].strftime(dhDateFormat)} - Doubleheader Game 2
 %else:
- - ${data[gamePk]['gameTime']['myTeam'].strftime('%a, %b %d @ %I:%M %p %Z')}\
+ - ${data[gamePk]['gameTime']['myTeam'].strftime(dateFormat)}\
 %endif
 %if data[gamePk]['schedule']['doubleHeader'] == 'S':
  - Doubleheader Game ${data[gamePk]['schedule']['gameNumber']}

--- a/bots/game_threads/templates/scoring_plays.mako
+++ b/bots/game_threads/templates/scoring_plays.mako
@@ -1,13 +1,17 @@
 ## Scoring plays
 <%
 	sortedPlays = []
-	if not data[gamePk]['schedule'].get('scoringPlays'):
+	if not len(data[gamePk]['gumbo']["liveData"]["plays"].get('scoringPlays', [])):
 		return
 	else:
 		unorderedPlays = {}
-		for s in data[gamePk]['schedule']['scoringPlays']:
-			if s['result'].get('description'):
-				unorderedPlays.update({s['about']['endTime'] : s})
+		for i in data[gamePk]['gumbo']["liveData"]["plays"]["scoringPlays"]:
+			play = next(
+				(p for p in data[gamePk]['gumbo']["liveData"]["plays"]["allPlays"] if p.get("atBatIndex") == i),
+				None,
+			)
+			if play and play['result'].get('description'):
+				unorderedPlays.update({play["about"]["endTime"]: play})
 
 		for x in sorted(unorderedPlays):
 			sortedPlays.append(unorderedPlays[x])

--- a/bots/game_threads/templates/weekly_title.mako
+++ b/bots/game_threads/templates/weekly_title.mako
@@ -1,8 +1,9 @@
 <%
     from datetime import datetime 
+    dateFormat = settings.get("Weekly Thread", {}).get("DATE_FORMAT","%A, %B %d")
 %>\
 Weekly ${data[0]['myTeam']['teamName']} \
 ${'Discussion Thread' if data[0]['myTeam']['seasonState'] in ['pre','regular','post:in'] else ''}\
 ${'Postseason Discussion Thread' if data[0]['myTeam']['seasonState'] == 'post:out' else ''}\
 ${'Offseason Discussion Thread' if data[0]['myTeam']['seasonState'].startswith('off') else ''}\
- - ${datetime.strptime(data[0]['today']['Ymd'],'%Y%m%d').strftime('%A, %B %d')}
+ - ${datetime.strptime(data[0]['today']['Ymd'],'%Y%m%d').strftime(dateFormat)}

--- a/bots/nfl_game_threads/__init__.py
+++ b/bots/nfl_game_threads/__init__.py
@@ -147,6 +147,7 @@ class Bot(object):
             self.log.debug("Today is {}".format(self.today["Y-m-d"]))
 
             # (Re-)Initialize NFL API
+            self.log.debug(f"Initializing NFL API with nflapi v{nflapi.__version__}")
             self.nfl = nflapi.APISession(self.getNflToken())
             # Start a scheduled task to refresh NFL API token before it expires
             self.SCHEDULER.add_job(

--- a/bots/nfl_game_threads/__init__.py
+++ b/bots/nfl_game_threads/__init__.py
@@ -1,0 +1,2831 @@
+#!/usr/bin/env python
+# encoding=utf-8
+"""NFL Game Thread Bot
+by Todd Roberts
+"""
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from datetime import datetime, timedelta
+import json
+import pytz
+import requests
+import sys
+import traceback
+import tzlocal
+import time
+
+import threading
+
+import redball
+from redball import database as rbdb, logger
+
+import os
+
+from mako.lookup import TemplateLookup
+import mako.exceptions
+
+import nflapi
+import pyprowl
+import twitter
+
+import praw
+
+__version__ = "1.0-alpha"
+
+DATA_LOCK = threading.Lock()
+
+
+def run(bot, settings):
+    thisBot = Bot(bot, settings)
+    thisBot.run()
+
+
+class Bot(object):
+    def __init__(self, bot, settings):
+        self.bot = bot
+        self.settings = settings
+        self.staleThreads = []
+        self.BOT_PATH = os.path.dirname(os.path.realpath(__file__))
+        self.BOT_TEMPLATE_PATH = []
+        if self.settings.get("Bot", {}).get("TEMPLATE_PATH", "") != "":
+            self.BOT_TEMPLATE_PATH.append(self.settings["Bot"]["TEMPLATE_PATH"])
+        self.BOT_TEMPLATE_PATH.append(os.path.join(self.BOT_PATH, "templates"))
+
+        self.LOOKUP = TemplateLookup(directories=self.BOT_TEMPLATE_PATH)
+
+    def run(self):
+        self.log = logger.init_logger(
+            logger_name="redball.bots." + threading.current_thread().name,
+            log_to_console=self.settings.get("Logging", {}).get("LOG_TO_CONSOLE", True),
+            log_to_file=self.settings.get("Logging", {}).get("LOG_TO_FILE", True),
+            log_path=redball.LOG_PATH,
+            log_file="{}.log".format(threading.current_thread().name),
+            file_log_level=self.settings.get("Logging", {}).get("FILE_LOG_LEVEL"),
+            log_retention=self.settings.get("Logging", {}).get("LOG_RETENTION", 7),
+            console_log_level=self.settings.get("Logging", {}).get("CONSOLE_LOG_LEVEL"),
+            clear_first=True,
+            propagate=False,
+        )
+        self.log.debug(
+            "NFL Game Thread Bot v{} received settings: {}. Template path: {}".format(
+                __version__, self.settings, self.BOT_TEMPLATE_PATH
+            )
+        )
+
+        # Check db for tables and create if necessary
+        self.dbTablePrefix = self.settings.get("Database").get(
+            "dbTablePrefix", "nfl_gdt{}_".format(self.bot.id)
+        )
+        self.build_tables()
+
+        # Initialize Reddit API connection
+        self.init_reddit()
+
+        # Initialize scheduler
+        self.SCHEDULER = BackgroundScheduler(
+            timezone=tzlocal.get_localzone()
+            if str(tzlocal.get_localzone()) != "local"
+            else "America/New_York"
+        )
+        self.SCHEDULER.start()
+
+        self.bot.detailedState = {
+            "summary": {
+                "text": "Starting up, please wait 1 minute...",
+                "html": "Starting up, please wait 1 minute...",
+                "markdown": "Starting up, please wait 1 minute...",
+            }
+        }  # Initialize detailed state to a wait message
+
+        # Start a scheduled task to update self.bot.detailedState every minute
+        self.SCHEDULER.add_job(
+            self.bot_state, "interval", name=f"bot-{self.bot.id}-statusUpdateTask", minutes=1
+        )
+
+        settings_date = datetime.today().strftime("%Y-%m-%d")
+        if self.settings.get("NFL", {}).get("GAME_DATE_OVERRIDE", "") != "":
+            # Bot config says to treat specified date as 'today'
+            todayOverrideFlag = True
+        else:
+            todayOverrideFlag = False
+
+        while redball.SIGNAL is None and not self.bot.STOP:
+            # This is the daily loop
+            # Refresh settings
+            if settings_date != datetime.today().strftime("%Y-%m-%d"):
+                self.refresh_settings()
+                settings_date = datetime.today().strftime("%Y-%m-%d")
+
+            if todayOverrideFlag:
+                self.log.info(
+                    "Overriding game date per GAME_DATE_OVERRIDE setting [{}].".format(
+                        self.settings["NFL"]["GAME_DATE_OVERRIDE"]
+                    )
+                )
+                try:
+                    todayObj = datetime.strptime(
+                        self.settings["NFL"]["GAME_DATE_OVERRIDE"], "%Y-%m-%d"
+                    )
+                except Exception as e:
+                    self.log.error(
+                        "Error overriding game date. Falling back to today's date. Error: {}".format(
+                            e
+                        )
+                    )
+                    self.error_notification(
+                        "Error overriding game date. Falling back to today's date"
+                    )
+                    todayObj = datetime.today()
+            else:
+                todayObj = datetime.today()
+
+            self.today = {
+                "Y-m-d": todayObj.strftime("%Y-%m-%d"),
+                "Ymd": todayObj.strftime("%Y%m%d"),
+                "Y": todayObj.strftime("%Y"),
+            }
+            self.log.debug("Today is {}".format(self.today["Y-m-d"]))
+
+            # (Re-)Initialize NFL API
+            self.nfl = nflapi.APISession(self.getNflToken())
+            # Start a scheduled task to refresh NFL API token before it expires
+            self.SCHEDULER.add_job(
+                self.getNflToken,
+                "interval",
+                name="getNflToken",
+                kwargs={"nflSession": self.nfl},
+                minutes=58,
+            )
+
+            # Get info about configured team
+            if self.settings.get("NFL", {}).get("TEAM", "") == "":
+                self.log.critical("No team selected! Set NFL > TEAM in Bot Config.")
+                self.bot.STOP = True
+                break
+
+            self.allTeams = self.nfl.teams(season=self.today["Y"])["data"]
+
+            self.myTeam = next(
+                (
+                    x
+                    for x in self.allTeams
+                    if x["abbr"]
+                    == self.settings.get("NFL", {}).get("TEAM", "").split("|")[1]
+                ),
+                None,
+            )
+            if not self.myTeam:
+                self.log.critical(
+                    "Unable to look up team info! Check NFL > TEAM in Bot Config."
+                )
+                self.bot.STOP = True
+                break
+            self.log.info("Configured team: {}".format(self.myTeam["fullName"]))
+            self.log.debug(f"self.myTeam: {self.myTeam}")
+
+            # Get current week and games
+            if todayOverrideFlag:
+                todayOverrideFlag = (
+                    False  # Only override once, then go back to current date
+                )
+                currentWeekGames = self.nfl.gamesByWeek(
+                    season=self.settings.get("NFL", {}).get(
+                        "SEASON_OVERRIDE", self.today["Y"]
+                    ),
+                    week=self.settings.get("NFL", {}).get("WEEK_OVERRIDE", 0),
+                    seasonType=self.settings.get("NFL", {}).get(
+                        "SEASONTYPE_OVERRIDE", "UNKNOWN"
+                    ),
+                )["data"]
+                if len(currentWeekGames):
+                    currentWeek = currentWeekGames[0]["week"]
+                else:
+                    currentWeek = {
+                        "id": "unknown",
+                        "season": int(
+                            self.settings.get("NFL", {}).get(
+                                "SEASON_OVERRIDE", self.today["Y"]
+                            )
+                        ),
+                        "seasonType": self.settings.get("NFL", {}).get(
+                            "SEASONTYPE_OVERRIDE", "UNKNOWN"
+                        ),
+                        "week": int(
+                            self.settings.get("NFL", {}).get("WEEK_OVERRIDE", 0)
+                        ),
+                        "name": "Unknown",
+                        "weekType": self.settings.get("NFL", {}).get(
+                            "SEASONTYPE_OVERRIDE", "UNKNOWN"
+                        ),
+                    }
+                    weekOrderDifferential = {
+                        "HOF": 0,
+                        "PRE": 1,
+                        "REG": 5,
+                        "POST": 22,
+                        "PRO": 25,
+                        "SB": 26,
+                    }
+                    currentWeek.update(
+                        {
+                            "weekOrder": currentWeek["week"]
+                            + weekOrderDifferential[currentWeek["seasonType"]],
+                        }
+                    )
+            else:
+                currentWeek = self.nfl.currentWeek()
+                currentWeekGames = self.nfl.gamesByWeek(
+                    season=currentWeek["season"],
+                    week=currentWeek["week"],
+                    seasonType=currentWeek["seasonType"],
+                )["data"]
+            self.log.debug(
+                f"Season: {currentWeek['season']}; Season Type: {currentWeek['seasonType']}; Week: {currentWeek['week']}; WeekOrder: {currentWeek['weekOrder']}"
+            )
+
+            # Get today's games
+            todayGames = [
+                g
+                for g in currentWeekGames
+                if datetime.fromisoformat(g["gameTime"]).strftime("%Y-%m-%d")
+                == self.today["Y-m-d"]
+            ]
+            self.log.debug(f"Today's games: {todayGames}")
+            myTeamTodayGameId = next(
+                (
+                    g["id"]
+                    for g in todayGames
+                    if self.myTeam["abbr"]
+                    in [g["visitorTeam"]["abbr"], g["homeTeam"]["abbr"]]
+                ),
+                None,
+            )
+            self.log.debug(f"My team's game id for today: {myTeamTodayGameId}")
+
+            # (Re-)Initialize dict to hold game data
+            self.allData = {
+                "myTeam": self.myTeam,
+                "currentWeek": currentWeek,
+                "currentWeekGames": currentWeekGames,
+                "todayGames": todayGames,
+                "gameId": myTeamTodayGameId,
+            }
+            # Initialize vars to hold data about reddit and process threads
+            self.stopFlags = {"tailgate": False, "game": False, "post": False}
+            """ Holds flags to indicate when reddit threads should stop updating """
+            self.THREADS = {"tailgate": None, "game": None, "post": None}
+            """ Holds process threads that will post/monitor/update each reddit thread """
+            self.threadCache = {"tailgate": {}, "game": {}, "post": {}}
+            """ Holds reddit threads and related data """
+
+            isCanceled = False
+            if myTeamTodayGameId:
+                # Get game insights now so we can check for cancelation headlines
+                gameInsights = self.nfl.gameInsights(gameId=myTeamTodayGameId)["data"][
+                    "viewer"
+                ]["gameInsight"]["insightsByGames"]
+                isCanceled = self.isGameCanceled(gameInsights)
+
+            if not myTeamTodayGameId or (myTeamTodayGameId and isCanceled):
+                # It's not a game day
+                self.log.info(
+                    f"No games today!{' (Game canceled)' if isCanceled else ''}"
+                )
+                if redball.SIGNAL is not None or self.bot.STOP:
+                    break
+            else:
+                self.log.info(f"IT'S GAME DAY! gameId: {myTeamTodayGameId}")
+                gameById = self.nfl.gameById(gameId=myTeamTodayGameId)
+                self.log.debug(f"gameById: {gameById}")
+                gameDetailId = gameById["data"]["viewer"]["game"]["gameDetailId"]
+                self.log.debug(f"gameDetailId: {gameDetailId}")
+                homeVisitor = next(
+                    (
+                        "home"
+                        for g in todayGames
+                        if self.myTeam["abbr"] == g["homeTeam"]["abbr"]
+                    ),
+                    None,
+                )
+                if not homeVisitor:
+                    homeVisitor = next(
+                        (
+                            "visitor"
+                            for g in todayGames
+                            if self.myTeam["abbr"] == g["visitorTeam"]["abbr"]
+                        ),
+                        None,
+                    )
+                self.log.debug(f"My team is [{homeVisitor}] (homeVisitor)")
+                oppTeamId = next(
+                    (
+                        g[("visitor" if homeVisitor == "home" else "home") + "Team"][
+                            "id"
+                        ]
+                        for g in todayGames
+                        if g["id"] == myTeamTodayGameId
+                    ),
+                    None,
+                )
+                self.log.debug(f"oppTeamId: {oppTeamId}")
+                oppTeam = self.nfl.teamById(teamId=oppTeamId)
+                self.log.debug(f"oppTeam: {oppTeam}")
+                gameTime = next(
+                    (g["gameTime"] for g in todayGames if g["id"] == myTeamTodayGameId),
+                    None,
+                )
+                self.log.debug(f"gameTime: {gameTime}")
+                myGameIndex = next(
+                    (
+                        k
+                        for k, v in enumerate(todayGames)
+                        if v["id"] == self.allData["gameId"]
+                    ),
+                    None,
+                )
+                gameStats = self.nfl.gameStats(
+                    gameId=myTeamTodayGameId,
+                    teamId=todayGames[myGameIndex][
+                        "visitorTeam" if homeVisitor == "visitor" else "homeTeam"
+                    ]["id"],
+                )["data"]["viewer"]["stats"]["teamGameStats"]["edges"]
+                gameStats = gameStats[0]["node"] if len(gameStats) else {}
+                standings = self.nfl.standings(
+                    season=currentWeek["season"], seasonType=currentWeek["seasonType"]
+                )["data"]
+                # Initialize var to hold game data throughout the day
+                self.allData.update(
+                    {
+                        "myTeam": self.nfl.teamById(teamId=todayGames[myGameIndex][homeVisitor + "Team"]["id"]),
+                        "gameDetailId": gameDetailId,
+                        "gameDetails": self.nfl.gameDetails(gameDetailId=gameDetailId)[
+                            "data"
+                        ]["viewer"]["gameDetail"]
+                        if gameDetailId
+                        else {},
+                        "gameInsights": gameInsights,
+                        "gameStats": gameStats,
+                        "homeVisitor": homeVisitor,
+                        "oppTeam": oppTeam,
+                        "gameTime": {
+                            "homeTeam": datetime.fromisoformat(gameTime),
+                            "bot": self.convert_timezone(
+                                datetime.fromisoformat(gameTime), "local",
+                            ),
+                            "myTeam": self.convert_timezone(
+                                datetime.fromisoformat(gameTime),
+                                self.settings.get("Bot", {}).get(
+                                    "TEAM_TIMEZONE", "America/New_York"
+                                ),
+                            ),
+                        },
+                        "myGameIndex": myGameIndex,
+                        "standings": standings,
+                    }
+                )
+                """ Holds data about current week games, including detailed data for my team's game """
+                if redball.DEV:
+                    self.log.debug(f"allData: {self.allData}")
+
+                # Check DB for gameId
+                gq = f"select * from {self.dbTablePrefix}games where gameId = '{self.allData['gameId']}' and gameDate = '{self.today['Y-m-d']}';"
+                dbGames = rbdb.db_qry(gq, closeAfter=True, logg=self.log)
+
+                if dbGames and len(dbGames) > 0:
+                    self.log.debug("Game is already in the database.")
+                else:
+                    # Add game to DB
+                    q = (
+                        f"insert into {self.dbTablePrefix}games (gameId, gameDate, dateAdded) "
+                        f"values ('{self.allData['gameId']}', '{self.today['Y-m-d']}', {time.time()});"
+                    )
+                    rbdb.db_qry(q, commit=True, closeAfter=True, logg=self.log)
+
+                # Tailgate Thread
+                if not self.settings.get("Tailgate Thread", {}).get("ENABLED", True):
+                    self.log.info("Pre thread disabled.")
+                    self.stopFlags.update({"pre": True})
+                else:
+                    # Spawn a thread to wait for post time and then keep tailgate thread updated
+                    self.THREADS.update(
+                        {
+                            "tailgate": threading.Thread(
+                                target=self.tailgate_thread_update_loop,
+                                name="bot-{}-{}-tailgate".format(
+                                    self.bot.id, self.bot.name.replace(" ", "-")
+                                ),
+                                daemon=True,
+                            )
+                        }
+                    )
+                    self.THREADS["tailgate"].start()
+                    self.log.debug(
+                        "Started tailgate thread {}.".format(self.THREADS["tailgate"])
+                    )
+
+                # Game thread update processes
+                if self.settings.get("Game Thread", {}).get("ENABLED", True):
+                    # Spawn separate thread to wait for post time and then keep game thread updated
+                    self.THREADS.update(
+                        {
+                            "game": threading.Thread(
+                                target=self.game_thread_update_loop,
+                                name="bot-{}-{}-game".format(
+                                    self.bot.id, self.bot.name.replace(" ", "-"),
+                                ),
+                                daemon=True,
+                            )
+                        }
+                    )
+                    self.THREADS["game"].start()
+                    self.log.debug(
+                        "Started game thread {}.".format(self.THREADS["game"])
+                    )
+                else:
+                    self.log.info("Game thread is disabled!")
+                    self.stopFlags.update({"game": True})
+
+                if self.settings.get("Post Game Thread", {}).get("ENABLED", True):
+                    # Spawn separate thread to wait for game to be final and then submit and keep post game thread updated
+                    self.THREADS.update(
+                        {
+                            "post": threading.Thread(
+                                target=self.postgame_thread_update_loop,
+                                name="bot-{}-{}-postgame".format(
+                                    self.bot.id, self.bot.name.replace(" ", "-"),
+                                ),
+                                daemon=True,
+                            )
+                        }
+                    )
+                    self.THREADS["post"].start()
+                    self.log.debug(
+                        "Started post game thread {}.".format(self.THREADS["post"])
+                    )
+                else:
+                    self.log.info("Post game thread is disabled!")
+                    self.stopFlags.update({"post": True})
+
+                # Loop while there are still active threads, make sure submit/update threads are running
+                while (
+                    next((k for k, v in self.stopFlags.items() if not v), None)
+                    and redball.SIGNAL is None
+                    and not self.bot.STOP
+                ):
+                    # Check submit/update thread for game thread
+                    try:
+                        if not self.settings.get("Game Thread", {}).get(
+                            "ENABLED", True
+                        ):
+                            # Game thread is disabled, so don't start an update thread...
+                            pass
+                        elif (
+                            not self.stopFlags["game"]
+                            and self.THREADS.get("game")
+                            and isinstance(self.THREADS["game"], threading.Thread,)
+                            and self.THREADS["game"].isAlive()
+                        ):
+                            self.log.debug(
+                                "Game thread looks fine..."
+                            )  # debug - need this here to see if the condition is working when the thread crashes
+                            # pass
+                        elif self.stopFlags["game"]:
+                            # Game thread is already done
+                            pass
+                        else:
+                            raise Exception(
+                                "Game thread update process is not running!"
+                            )
+                    except Exception as e:
+                        if "is not running" in str(e):
+                            self.log.error(
+                                "Game thread update process is not running. Attempting to start."
+                            )
+                            self.error_notification(
+                                "Game thread update process is not running"
+                            )
+                            self.THREADS.update(
+                                {
+                                    "game": threading.Thread(
+                                        target=self.game_thread_update_loop,
+                                        name="bot-{}-{}-game".format(
+                                            self.bot.id,
+                                            self.bot.name.replace(" ", "-"),
+                                        ),
+                                        daemon=True,
+                                    )
+                                }
+                            )
+                            self.THREADS["game"].start()
+                            self.log.debug(
+                                "Started game thread {}.".format(self.THREADS["game"])
+                            )
+                        else:
+                            raise
+
+                    # Check submit/update thread for post game thread
+                    try:
+                        if not self.settings.get("Post Game Thread", {}).get(
+                            "ENABLED", True
+                        ):
+                            # Post game thread is disabled, so don't start an update thread...
+                            pass
+                        elif (
+                            not self.stopFlags["post"]
+                            and self.THREADS.get("post")
+                            and isinstance(self.THREADS["post"], threading.Thread,)
+                            and self.THREADS["post"].isAlive()
+                        ):
+                            self.log.debug(
+                                "Post game thread looks fine..."
+                            )  # debug - need this here to see if the condition is working when the thread crashes
+                            # pass
+                        elif self.stopFlags["post"]:
+                            # Post game thread is already done
+                            pass
+                        else:
+                            raise Exception(
+                                "Post game thread update process is not running!"
+                            )
+                    except Exception as e:
+                        if "is not running" in str(e):
+                            self.log.error(
+                                "Post game thread update process is not running. Attempting to start."
+                            )
+                            self.error_notification(
+                                "Post game thread update process is not running"
+                            )
+                            self.THREADS.update(
+                                {
+                                    "post": threading.Thread(
+                                        target=self.postgame_thread_update_loop,
+                                        name="bot-{}-{}-postgame".format(
+                                            self.bot.id,
+                                            self.bot.name.replace(" ", "-"),
+                                        ),
+                                        daemon=True,
+                                    )
+                                }
+                            )
+                            self.THREADS["post"].start()
+                            self.log.debug(
+                                "Started post game thread {}.".format(
+                                    self.THREADS["post"]
+                                )
+                            )
+                        else:
+                            raise
+
+                    # Make sure tailgate thread update process is running
+                    try:
+                        if not self.settings.get("Tailgate Thread", {}).get(
+                            "ENABLED", True
+                        ):
+                            # Tailgate thread is disabled, so don't start an update thread...
+                            pass
+                        elif (
+                            not self.stopFlags["tailgate"]
+                            and self.THREADS.get("tailgate")
+                            and isinstance(self.THREADS["tailgate"], threading.Thread)
+                            and self.THREADS["tailgate"].isAlive()
+                        ):
+                            self.log.debug(
+                                "Tailgate update thread looks fine..."
+                            )  # debug - need this here to see if the condition is working when the thread crashes
+                            # pass
+                        elif self.stopFlags["tailgate"]:
+                            # Tailgate thread is already done
+                            pass
+                        else:
+                            raise Exception(
+                                "Tailgate thread update process is not running!"
+                            )
+                    except Exception as e:
+                        if "is not running" in str(e):
+                            self.log.error(
+                                "Tailgate thread update process is not running. Attempting to start. Error: {}".format(
+                                    e
+                                )
+                            )
+                            self.error_notification(
+                                "Tailgate thread update process is not running"
+                            )
+                            self.THREADS.update(
+                                {
+                                    "tailgate": threading.Thread(
+                                        target=self.tailgate_thread_update_loop,
+                                        name="bot-{}-{}-tailgate".format(
+                                            self.bot.id,
+                                            self.bot.name.replace(" ", "-"),
+                                        ),
+                                        daemon=True,
+                                    )
+                                }
+                            )
+                            self.THREADS["tailgate"].start()
+                            self.log.debug(
+                                "Started tailgate thread {}.".format(
+                                    self.THREADS["tailgate"]
+                                )
+                            )
+                        else:
+                            raise
+
+                    if next((k for k, v in self.stopFlags.items() if not v), None):
+                        # There are still threads pending/in progress
+                        self.log.debug(
+                            "Thread(s) with negative stop flags: {}".format(
+                                [k for k, v in self.stopFlags.items() if not v]
+                            )
+                        )
+                        self.log.debug(
+                            "Active update process threads: {}".format(
+                                [
+                                    t
+                                    for t in threading.enumerate()
+                                    if t.name.startswith(
+                                        "bot-{}-{}".format(
+                                            self.bot.id,
+                                            self.bot.name.replace(" ", "-"),
+                                        )
+                                    )
+                                ]
+                            )
+                        )
+                        self.sleep(30)
+                    else:
+                        break
+
+                if redball.SIGNAL is not None or self.bot.STOP:
+                    break
+
+            self.log.info("All done for today! Going into end of day loop...")
+            self.eod_loop(self.today["Y-m-d"])
+
+        self.SCHEDULER.shutdown()
+        self.log.info("Bot {} (id={}) exiting...".format(self.bot.name, self.bot.id))
+        self.bot.detailedState = {
+            "lastUpdated": datetime.today().strftime("%m/%d/%Y %I:%M:%S %p"),
+            "summary": {
+                "text": "Bot has been stopped.",
+                "html": "Bot has been stopped.",
+                "markdown": "Bot has been stopped.",
+            },
+        }
+
+    def tailgate_thread_update_loop(self):
+        skipFlag = None  # Will be set later if tailgate thread edit should be skipped
+
+        # Check/wait for time to submit tailgate thread
+        self.threadCache["tailgate"].update(
+            {
+                "postTime_local": datetime.strptime(
+                    datetime.today().strftime(
+                        "%Y-%m-%d "
+                        + self.settings.get("Tailgate Thread", {}).get(
+                            "POST_TIME", "05:00"
+                        )
+                    ),
+                    "%Y-%m-%d %H:%M",
+                )
+            }
+        )
+        self.log.debug(
+            "Tailgate thread post time: {}".format(
+                self.threadCache["tailgate"]["postTime_local"]
+            )
+        )
+        while (
+            datetime.today() < self.threadCache["tailgate"]["postTime_local"]
+            and redball.SIGNAL is None
+            and not self.bot.STOP
+        ):
+            if (
+                self.threadCache["tailgate"]["postTime_local"] - datetime.today()
+            ).total_seconds() > 3600:
+                self.log.info(
+                    "Tailgate thread should not be posted for a long time ({}). Sleeping for an hour...".format(
+                        self.threadCache["tailgate"]["postTime_local"]
+                    )
+                )
+                self.sleep(3600)
+            elif (
+                self.threadCache["tailgate"]["postTime_local"] - datetime.today()
+            ).total_seconds() > 1800:
+                self.log.info(
+                    "Tailgate thread post time is still more than 30 minutes away ({}). Sleeping for a half hour...".format(
+                        self.threadCache["tailgate"]["postTime_local"]
+                    )
+                )
+                self.sleep(1800)
+            else:
+                self.log.info(
+                    "Tailgate thread post time is approaching ({}). Sleeping until then...".format(
+                        self.threadCache["tailgate"]["postTime_local"]
+                    )
+                )
+                self.sleep(
+                    (
+                        self.threadCache["tailgate"]["postTime_local"]
+                        - datetime.today()
+                    ).total_seconds()
+                )
+
+        if redball.SIGNAL is not None or self.bot.STOP:
+            self.log.debug("Caught a stop signal...")
+            return
+
+        # Unsticky stale threads
+        if self.settings.get("Reddit", {}).get("STICKY", False):
+            if len(self.staleThreads):
+                self.unsticky_threads(self.staleThreads)
+                self.staleThreads = []
+
+        # Check if tailgate thread already posted (record in threads table with type='tailgate' for today's gameId)
+        tgq = f"select * from {self.dbTablePrefix}threads where type='tailgate' and gameId = '{self.allData['gameId']}' and gameDate = '{self.today['Y-m-d']}' and deleted=0;"
+        tgThread = rbdb.db_qry(tgq, closeAfter=True, logg=self.log)
+
+        tailgateThread = None
+        if len(tgThread) > 0:
+            self.log.info(f"Tailgate thread found in database [{tgThread[0]['id']}].")
+            tailgateThread = self.reddit.submission(tgThread[0]["id"])
+            if not tailgateThread.author:
+                self.log.warning("Tailgate thread appears to have been deleted.")
+                q = "update {}threads set deleted=1 where id='{}';".format(
+                    self.dbTablePrefix, tailgateThread.id
+                )
+                u = rbdb.db_qry(q, commit=True, closeAfter=True, logg=self.log)
+                if isinstance(u, str):
+                    self.log.error(
+                        "Error marking thread as deleted in database: {}".format(u)
+                    )
+
+                tailgateThread = None
+            else:
+                if tailgateThread.selftext.find("\n\n^^^Last ^^^Updated") != -1:
+                    tailgateThreadText = tailgateThread.selftext[
+                        0 : tailgateThread.selftext.find("\n\n^^^Last ^^^Updated:")
+                    ]
+                elif tailgateThread.selftext.find("\n\n^^^Posted") != -1:
+                    tailgateThreadText = tailgateThread.selftext[
+                        0 : tailgateThread.selftext.find("\n\n^^^Posted:")
+                    ]
+                else:
+                    tailgateThreadText = tailgateThread.selftext
+
+                self.threadCache["tailgate"].update(
+                    {
+                        "text": tailgateThreadText,
+                        "thread": tailgateThread,
+                        "title": tailgateThread.title
+                        if tailgateThread not in [None, False]
+                        else None,
+                    }
+                )
+                # Only sticky when posting the thread
+                # if self.settings.get('Reddit',{}).get('STICKY',False): self.sticky_thread(tailgateThread)
+
+        if not tailgateThread:
+            # Submit tailgate thread
+            (tailgateThread, tailgateThreadText) = self.prep_and_post(
+                "tailgate",
+                postFooter="""
+
+^^^Posted: ^^^"""
+                + self.convert_timezone(
+                    datetime.utcnow(),
+                    self.settings.get("Bot", {}).get(
+                        "TEAM_TIMEZONE", "America/New_York"
+                    ),
+                ).strftime("%m/%d/%Y ^^^%I:%M:%S ^^^%p ^^^%Z")
+                + ", ^^^Update ^^^Interval: ^^^{} ^^^Minutes".format(
+                    self.settings.get("Tailgate Thread", {}).get("UPDATE_INTERVAL", 5)
+                ),
+            )
+            self.threadCache["tailgate"].update(
+                {
+                    "text": tailgateThreadText,
+                    "thread": tailgateThread,
+                    "title": tailgateThread.title
+                    if tailgateThread not in [None, False]
+                    else None,
+                }
+            )
+            skipFlag = True
+        else:
+            self.threadCache["tailgate"].update({"thread": tailgateThread})
+
+        while (
+            not self.stopFlags["tailgate"]
+            and redball.SIGNAL is None
+            and not self.bot.STOP
+        ):
+            # Keep tailgate thread updated
+            if skipFlag:
+                # Skip check/edit since skip flag is set
+                skipFlag = None
+                self.log.debug(
+                    "Skip flag is set, tailgate thread was just submitted/edited and does not need to be checked."
+                )
+            else:
+                try:
+                    # Update data
+                    self.collect_data()
+                    # self.log.debug('data passed into render_template: {}'.format(self.allData))#debug
+                    text = self.render_template(
+                        thread="tailgate",
+                        templateType="thread",
+                        data=self.allData,
+                        settings=self.settings,
+                    )
+                    self.log.debug("Rendered tailgate thread text: {}".format(text))
+                    if text != self.threadCache["tailgate"].get("text") and text != "":
+                        self.threadCache["tailgate"].update({"text": text})
+                        text += (
+                            """
+
+^^^Last ^^^Updated: ^^^"""
+                            + self.convert_timezone(
+                                datetime.utcnow(),
+                                self.settings.get("Bot", {}).get(
+                                    "TEAM_TIMEZONE", "America/New_York"
+                                ),
+                            ).strftime("%m/%d/%Y ^^^%I:%M:%S ^^^%p ^^^%Z")
+                            + ", ^^^Update ^^^Interval: ^^^{} ^^^Minutes".format(
+                                self.settings.get("Tailgate Thread", {}).get(
+                                    "UPDATE_INTERVAL", 5
+                                )
+                            )
+                        )
+                        self.threadCache["tailgate"]["thread"].edit(text)
+                        self.log.info("Tailgate thread edits submitted.")
+                        self.count_check_edit(
+                            self.threadCache["tailgate"]["thread"].id, "NA", edit=True
+                        )
+                        self.log_last_updated_date_in_db(
+                            self.threadCache["tailgate"]["thread"].id
+                        )
+                    elif text == "":
+                        self.log.info(
+                            "Skipping tailgate thread edit since thread text is blank..."
+                        )
+                    else:
+                        self.log.info("No changes to tailgate thread.")
+                        self.count_check_edit(
+                            self.threadCache["tailgate"]["thread"].id, "NA", edit=False
+                        )
+                except Exception as e:
+                    self.log.error("Error editing tailgate thread: {}".format(e))
+                    self.error_notification("Error editing tailgate thread")
+
+            update_tailgate_thread_until = self.settings.get("Tailgate Thread", {}).get(
+                "UPDATE_UNTIL", "Game thread is posted"
+            )
+            if update_tailgate_thread_until not in [
+                "Do not update",
+                "Game thread is posted",
+                "All division games are final",
+                "All NFL games are final",
+            ]:
+                # Unsupported value, use default
+                update_tailgate_thread_until = "Game thread is posted"
+
+            if not self.settings.get("Tailgate Thread", {}).get("ENABLED", True):
+                # Tailgate thread is already posted, but disabled. Don't update it.
+                self.log.info(
+                    "Stopping tailgate thread update loop because tailgate thread is disabled."
+                )
+                self.stopFlags.update({"tailgate": True})
+                break
+            elif update_tailgate_thread_until == "Do not update":
+                # Setting says not to update
+                self.log.info(
+                    "Stopping tailgate thread update loop per UPDATE_UNTIL setting."
+                )
+                self.stopFlags.update({"tailgate": True})
+                break
+            elif update_tailgate_thread_until == "Game thread is posted":
+                if self.threadCache["game"].get("thread"):
+                    # Game thread is posted
+                    self.log.info(
+                        "Game thread is posted. Stopping tailgate thread update loop per UPDATE_UNTIL setting."
+                    )
+                    self.stopFlags.update({"tailgate": True})
+                    break
+            elif update_tailgate_thread_until == "All division games are final":
+                if (  # This game is final
+                    self.allData["todayGames"][self.allData["myGameIndex"]][
+                        "gameStatus"
+                    ]["phase"]
+                    in ["FINAL", "FINAL_OVERTIME", "SUSPENDED", "CANCELED", "CANCELLED"]
+                ) and not next(  # And all division games are final
+                    (
+                        True
+                        for x in self.allData["todayGames"]
+                        if x["gameStatus"]["phase"] in ["PREGAME", "INGAME", "HALFTIME"]
+                        and any(
+                            (
+                                True
+                                for divTeamId in self.otherDivisionTeams
+                                if divTeamId["id"]
+                                in [x["visitorTeam"]["id"], x["homeTeam"]["id"]]
+                            )
+                        )
+                    ),
+                    False,
+                ):
+                    # Division games are all final
+                    self.log.info(
+                        "All division games are final. Stopping tailgate thread update loop per UPDATE_UNTIL setting."
+                    )
+                    self.stopFlags.update({"tailgate": True})
+                    break
+            elif update_tailgate_thread_until == "All NFL games are final":
+                if not next(  # All NFL games are final
+                    (
+                        True
+                        for x in self.allData["todayGames"]
+                        if x["gameStatus"]["phase"] in ["PREGAME", "INGAME", "HALFTIME"]
+                    ),
+                    False,
+                ):
+                    # NFL games are all final
+                    self.log.info(
+                        "All NFL games are final. Stopping tailgate thread update loop per UPDATE_UNTIL setting."
+                    )
+                    self.stopFlags.update({"tailgate": True})
+                    break
+
+            self.log.debug(
+                "Tailgate thread stop criteria not met ({}).".format(
+                    update_tailgate_thread_until
+                )
+            )  # debug - need this to tell if logic is working
+
+            # Update interval is in minutes (seconds for game thread only)
+            tgtWait = self.settings.get("Tailgate Thread", {}).get("UPDATE_INTERVAL", 5)
+            if tgtWait < 1:
+                tgtWait = 1
+            self.log.info("Sleeping for {} minutes...".format(tgtWait))
+            self.sleep(tgtWait * 60)
+
+        if redball.SIGNAL is not None or self.bot.STOP:
+            self.log.debug("Caught a stop signal...")
+            return
+
+        # Mark tailgate thread as stale
+        if self.threadCache["tailgate"].get("thread"):
+            self.staleThreads.append(self.threadCache["tailgate"]["thread"])
+
+        self.log.debug("Ending tailgate update thread...")
+        return
+
+    def game_thread_update_loop(self):
+        skipFlag = (
+            None  # Will be set later if game thread submit/edit should be skipped
+        )
+
+        # Check if game thread is already posted
+        gq = "select * from {}threads where type='game' and gameId = '{}' and gameDate = '{}' and deleted=0;".format(
+            self.dbTablePrefix, self.allData["gameId"], self.today["Y-m-d"]
+        )
+        gThread = rbdb.db_qry(gq, closeAfter=True, logg=self.log)
+
+        gameThread = None
+        if len(gThread) > 0:
+            self.log.info("Game thread found in database [{}]".format(gThread[0]["id"]))
+            gameThread = self.reddit.submission(gThread[0]["id"])
+            if not gameThread.author:
+                self.log.warning("Game thread appears to have been deleted.")
+                q = "update {}threads set deleted=1 where id='{}';".format(
+                    self.dbTablePrefix, gameThread.id
+                )
+                u = rbdb.db_qry(q, commit=True, closeAfter=True, logg=self.log)
+                if isinstance(u, str):
+                    self.log.error(
+                        "Error marking thread as deleted in database: {}".format(u)
+                    )
+
+                gameThread = None
+            else:
+                if gameThread.selftext.find("\n\n^^^Last ^^^Updated") != -1:
+                    gameThreadText = gameThread.selftext[
+                        0 : gameThread.selftext.find("\n\n^^^Last ^^^Updated:")
+                    ]
+                elif gameThread.selftext.find("\n\n^^^Posted") != -1:
+                    gameThreadText = gameThread.selftext[
+                        0 : gameThread.selftext.find("\n\n^^^Posted:")
+                    ]
+                else:
+                    gameThreadText = gameThread.selftext
+
+                self.threadCache["game"].update(
+                    {
+                        "thread": gameThread,
+                        "text": gameThreadText,
+                        "title": gameThread.title
+                        if gameThread not in [None, False]
+                        else None,
+                    }
+                )
+                # Only sticky when posting the thread
+                # if self.settings.get('Reddit',{}).get('STICKY',False): self.sticky_thread(self.threadCache['game']['thread'])
+
+        if not gameThread:
+            # Determine time to post
+            gameStart = self.allData["gameTime"]["bot"]
+            postBy = tzlocal.get_localzone().localize(
+                datetime.strptime(
+                    datetime.today().strftime(
+                        "%Y-%m-%d "
+                        + self.settings.get("Game Thread", {}).get("POST_BY", "23:59")
+                    ),
+                    "%Y-%m-%d %H:%M",
+                )
+            )
+            minBefore = int(
+                self.settings.get("Game Thread", {}).get("MINUTES_BEFORE", 180)
+            )
+            minBefore_time = gameStart - timedelta(minutes=minBefore)
+            self.threadCache["game"].update(
+                {
+                    "postTime": min(gameStart, postBy, minBefore_time),
+                    "postTime_local": min(gameStart, postBy, minBefore_time).replace(
+                        tzinfo=None
+                    ),
+                }
+            )
+            self.log.debug(
+                "Game thread post time: {} (min of Game Start: {}, Post By: {}, Min Before: {})".format(
+                    self.threadCache["game"]["postTime_local"],
+                    gameStart,
+                    postBy,
+                    minBefore_time,
+                )
+            )
+
+            # Check/wait for time to submit game thread
+            while (
+                datetime.today() < self.threadCache["game"]["postTime_local"]
+                and redball.SIGNAL is None
+                and not self.bot.STOP
+                and not self.threadCache["game"].get("thread")
+            ):
+                if self.allData["todayGames"][self.allData["myGameIndex"]][
+                    "gameStatus"
+                ]["phase"] in [
+                    "SUSPENDED",
+                    "FINAL",
+                    "FINAL_OVERTIME",
+                    "CANCELED",
+                    "CANCELLED",
+                ]:
+                    if not self.settings.get("Post Game Thread", {}).get(
+                        "ENABLED", True
+                    ):
+                        # Post game thread is disabled
+                        if not self.settings.get("Game Thread", {}).get(
+                            "ENABLED", True
+                        ):
+                            # Game thread is also disabled
+                            skipFlag = True
+                        else:
+                            # Need to post game thread because post game thread is disabled
+                            skipFlag = False
+                    else:
+                        # Post game thread is enabled, so skip game thread
+                        self.log.info(
+                            "Game is {}; skipping game thread...".format(
+                                self.allData["todayGames"][self.allData["myGameIndex"]][
+                                    "gameStatus"
+                                ]["phase"],
+                            )
+                        )
+                        skipFlag = True
+                    break
+                elif self.allData["todayGames"][self.allData["myGameIndex"]][
+                    "gameStatus"
+                ]["phase"] in ["INGAME", "HALFTIME"]:
+                    # Game is already in live status (including halftime), so submit the game thread!
+                    self.log.info(
+                        "It's technically not time to submit the game thread yet, but the game status is INGAME/HALFTIME. Proceeding..."
+                    )
+                    break
+                elif not self.settings.get("Game Thread", {}).get("ENABLED", True):
+                    # Game thread is disabled
+                    self.log.info("Game thread is disabled.")
+                    skipFlag = True
+                    break
+
+                if (
+                    self.threadCache["game"]["postTime_local"] - datetime.today()
+                ).total_seconds() >= 600:
+                    self.log.info(
+                        "Waiting for time to submit game thread: {}. Sleeping for 10 minutes...".format(
+                            self.threadCache["game"]["postTime_local"],
+                        )
+                    )
+                    self.sleep(600)
+                else:
+                    self.log.info(
+                        "Game thread should be posted soon, sleeping until then ({})...".format(
+                            self.threadCache["game"]["postTime_local"]
+                        )
+                    )
+                    self.sleep(
+                        (
+                            self.threadCache["game"]["postTime_local"]
+                            - datetime.today()
+                        ).total_seconds()
+                    )
+
+            if redball.SIGNAL is not None or self.bot.STOP:
+                self.log.debug("Caught a stop signal...")
+                return
+
+            # Unsticky stale threads
+            if self.settings.get("Reddit", {}).get("STICKY", False):
+                # Make sure tailgate thread is marked as stale, since we want the game thread to be sticky instead
+                if (
+                    self.threadCache.get("tailgate", {}).get("thread")
+                    and self.threadCache["tailgate"]["thread"] not in self.staleThreads
+                ):
+                    self.staleThreads.append(self.threadCache["tailgate"]["thread"])
+
+                if len(self.staleThreads):
+                    self.unsticky_threads(self.staleThreads)
+                    self.staleThreads = []
+
+            if skipFlag or not self.settings.get("Game Thread", {}).get(
+                "ENABLED", True
+            ):
+                # Skip game thread since skip flag is set or game thread is disabled
+                if self.settings.get("Game Thread", {}).get("ENABLED", True):
+                    self.log.info("Skipping game thread...")
+                else:
+                    self.log.info("Game thread is disabled, so skipping...")
+            else:
+                # Submit Game Thread
+                self.log.info("Preparing to post game thread...")
+                (gameThread, gameThreadText) = self.prep_and_post(
+                    "game",
+                    postFooter="""
+
+^^^Posted: ^^^"""
+                    + self.convert_timezone(
+                        datetime.utcnow(),
+                        self.settings.get("Bot", {}).get(
+                            "TEAM_TIMEZONE", "America/New_York"
+                        ),
+                    ).strftime("%m/%d/%Y ^^^%I:%M:%S ^^^%p ^^^%Z"),
+                )
+                self.threadCache["game"].update(
+                    {
+                        "thread": gameThread,
+                        "text": gameThreadText,
+                        "title": gameThread.title
+                        if gameThread not in [None, False]
+                        else None,
+                    }
+                )
+
+            # Thread is not posted, so don't start an update loop
+            if not self.threadCache["game"].get("thread") and self.settings.get(
+                "Game Thread", {}
+            ).get("ENABLED", True):
+                # Game thread is enabled but failed to post
+                self.log.info("Game thread not posted. Ending update loop...")
+                self.stopFlags.update({"game": True})
+                return  # TODO: Determine why thread is not posted and retry if temporary issue
+
+            skipFlag = True  # Skip first edit since the thread was just posted
+
+        while (
+            not self.stopFlags["game"] and redball.SIGNAL is None and not self.bot.STOP
+        ):
+            if skipFlag:
+                # Skip edit since thread was just posted
+                skipFlag = None
+                self.log.debug(
+                    "Skip flag is set, game thread does not need to be edited."
+                )
+            else:
+                # Re-generate game thread code, compare to current code, edit if different
+                # Update data
+                self.collect_data()
+                text = self.render_template(
+                    thread="game",
+                    templateType="thread",
+                    data=self.allData,
+                    settings=self.settings,
+                )
+                self.log.debug(f"rendered game thread text: {text}")
+                if text != self.threadCache["game"].get("text") and text != "":
+                    self.threadCache["game"].update({"text": text})
+                    # Add last updated timestamp
+                    text += """
+
+^^^Last ^^^Updated: ^^^""" + self.convert_timezone(
+                        datetime.utcnow(),
+                        self.settings.get("Bot", {}).get(
+                            "TEAM_TIMEZONE", "America/New_York"
+                        ),
+                    ).strftime(
+                        "%m/%d/%Y ^^^%I:%M:%S ^^^%p ^^^%Z"
+                    )
+                    self.threadCache["game"]["thread"].edit(text)
+                    self.log.info("Edits submitted for game thread.")
+                    self.count_check_edit(
+                        self.threadCache["game"]["thread"].id,
+                        self.allData["todayGames"][self.allData["myGameIndex"]][
+                            "gameStatus"
+                        ]["phase"],
+                        edit=True,
+                    )
+                    self.log_last_updated_date_in_db(
+                        self.threadCache["game"]["thread"].id
+                    )
+                elif text == "":
+                    self.log.info(
+                        "Skipping game thread edit since thread text is blank..."
+                    )
+                else:
+                    self.log.info("No changes to game thread.")
+                    self.count_check_edit(
+                        self.threadCache["game"]["thread"].id,
+                        self.allData["todayGames"][self.allData["myGameIndex"]][
+                            "gameStatus"
+                        ]["phase"],
+                        edit=False,
+                    )
+
+            update_game_thread_until = self.settings.get("Game Thread", {}).get(
+                "UPDATE_UNTIL", ""
+            )
+            if update_game_thread_until not in [
+                "Do not update",
+                "My team's game is final",
+                "All division games are final",
+                "All NFL games are final",
+            ]:
+                # Unsupported value, use default
+                update_game_thread_until = "All NFL games are final"
+
+            if update_game_thread_until == "Do not update":
+                # Setting says not to update
+                self.log.info(
+                    "Stopping game thread update loop per UPDATE_UNTIL setting."
+                )
+                self.stopFlags.update({"game": True})
+                break
+            elif update_game_thread_until == "My team's game is final":
+                if self.allData["todayGames"][self.allData["myGameIndex"]][
+                    "gameStatus"
+                ]["phase"] in [
+                    "FINAL",
+                    "FINAL_OVERTIME",
+                    "SUSPENDED",
+                    "CANCELED",
+                    "CANCELLED",
+                ]:
+                    # My team's game is final
+                    self.log.info(
+                        "My team's game is final. Stopping game thread update loop per UPDATE_UNTIL setting."
+                    )
+                    self.stopFlags.update({"game": True})
+                    break
+            elif update_game_thread_until == "All division games are final":
+                if (  # This game is final
+                    self.allData["todayGames"][self.allData["myGameIndex"]][
+                        "gameStatus"
+                    ]["phase"]
+                    in ["FINAL", "FINAL_OVERTIME", "SUSPENDED", "CANCELED", "CANCELLED"]
+                ) and not next(  # And all division games are final
+                    (
+                        True
+                        for x in self.allData["todayGames"]
+                        if x["gameStatus"]["phase"] in ["PREGAME", "INGAME", "HALFTIME"]
+                        and any(
+                            (
+                                True
+                                for divTeamId in self.otherDivisionTeams
+                                if divTeamId["id"]
+                                in [x["visitorTeam"]["id"], x["homeTeam"]["id"]]
+                            )
+                        )
+                    ),
+                    False,
+                ):
+                    # Division games are all final
+                    self.log.info(
+                        "All division games are final. Stopping game thread update loop per UPDATE_UNTIL setting."
+                    )
+                    self.stopFlags.update({"game": True})
+                    break
+            elif update_game_thread_until == "All NFL games are final":
+                if not next(  # All NFL games are final
+                    (
+                        True
+                        for x in self.allData["todayGames"]
+                        if x["gameStatus"]["phase"] in ["PREGAME", "INGAME", "HALFTIME"]
+                    ),
+                    False,
+                ):
+                    # NFL games are all final
+                    self.log.info(
+                        "All NFL games are final. Stopping game thread update loop per UPDATE_UNTIL setting."
+                    )
+                    self.stopFlags.update({"game": True})
+                    break
+
+            self.log.debug(
+                "Game thread stop criteria not met ({}).".format(
+                    update_game_thread_until
+                )
+            )  # debug - need this to tell if logic is working
+
+            if (
+                self.allData["todayGames"][self.allData["myGameIndex"]]["gameStatus"][
+                    "phase"
+                ]
+                == "HALFTIME"
+            ):
+                # Game is at halftime
+                # Update interval is in minutes (seconds only when game is live)
+                gtnlWait = self.settings.get("Game Thread", {}).get(
+                    "UPDATE_INTERVAL_NOT_LIVE", 1
+                )
+                if gtnlWait < 1:
+                    gtnlWait = 1
+                self.log.info(
+                    "Game is at halftime, sleeping for {} minutes...".format(gtnlWait,)
+                )
+                self.sleep(gtnlWait * 60)
+            elif (
+                self.allData["todayGames"][self.allData["myGameIndex"]]["gameStatus"][
+                    "phase"
+                ]
+                == "INGAME"
+            ):
+                # Update interval is in seconds (minutes for all other cases)
+                gtWait = self.settings.get("Game Thread", {}).get("UPDATE_INTERVAL", 10)
+                if gtWait < 1:
+                    gtWait = 1
+                self.log.info(
+                    "Game is live, sleeping for {} seconds...".format(gtWait,)
+                )
+                self.sleep(gtWait)
+            else:
+                # Update interval is in minutes (seconds only when game is live)
+                gtnlWait = self.settings.get("Game Thread", {}).get(
+                    "UPDATE_INTERVAL_NOT_LIVE", 1
+                )
+                if gtnlWait < 1:
+                    gtnlWait = 1
+                self.log.info(
+                    "Game is not live ({}), sleeping for {} minutes...".format(
+                        self.allData["todayGames"][self.allData["myGameIndex"]][
+                            "gameStatus"
+                        ]["phase"],
+                        gtnlWait,
+                    )
+                )
+                self.sleep(gtnlWait * 60)
+
+        if redball.SIGNAL is not None or self.bot.STOP:
+            self.log.debug("Caught a stop signal...")
+            return
+
+        self.log.info("All finished with this game!")
+        self.stopFlags.update({"game": True})
+
+        # Mark game thread as stale
+        if self.threadCache["game"].get("thread"):
+            self.staleThreads.append(self.threadCache["game"]["thread"])
+
+        self.log.debug("Ending game update thread...")
+        return
+
+    def postgame_thread_update_loop(self):
+        skipFlag = (
+            None  # Will be set later if post game thread submit/edit should be skipped
+        )
+
+        while redball.SIGNAL is None and not self.bot.STOP:
+            if self.allData["todayGames"][self.allData["myGameIndex"]]["gameStatus"][
+                "phase"
+            ] in ["FINAL", "FINAL_OVERTIME", "SUSPENDED", "CANCELED", "CANCELLED"]:
+                # Game is over
+                self.log.info(
+                    "Game is over ({}). Proceeding with post game thread...".format(
+                        self.allData["todayGames"][self.allData["myGameIndex"]][
+                            "gameStatus"
+                        ]["phase"],
+                    )
+                )
+                break
+            elif self.stopFlags["game"]:
+                # Game thread process has stopped, but game status isn't final yet... get fresh data!
+                self.log.info(
+                    f"Game thread process has ended, but cached game status is still ({self.allData['todayGames'][self.allData['myGameIndex']]['gameStatus']['phase']}). Refreshing data..."
+                )
+                # Update data
+                self.collect_data()
+            else:
+                self.log.debug(
+                    "Game is not yet final ({}). Sleeping for 1 minute...".format(
+                        self.allData["todayGames"][self.allData["myGameIndex"]][
+                            "gameStatus"
+                        ]["phase"],
+                    )
+                )
+                self.sleep(60)
+
+        if redball.SIGNAL is not None or self.bot.STOP:
+            self.log.debug("Caught a stop signal...")
+            return
+
+        # Unsticky stale threads
+        if self.settings.get("Reddit", {}).get("STICKY", False):
+            # Make sure game thread is marked as stale, since we want the post game thread to be sticky instead
+            if (
+                self.threadCache["game"].get("thread")
+                and self.threadCache["game"]["thread"] not in self.staleThreads
+            ):
+                self.staleThreads.append(self.threadCache["game"]["thread"])
+
+            if len(self.staleThreads):
+                self.unsticky_threads(self.staleThreads)
+                self.staleThreads = []
+
+        # TODO: Loop in case thread creation fails due to title template error or API error? At least break from update loop...
+        # Game is over - check if postgame thread already posted (record in db with gameId and type='post' and gameDate=today)
+        pgq = "select * from {}threads where type='post' and gameId = '{}' and gameDate = '{}' and deleted=0;".format(
+            self.dbTablePrefix, self.allData["gameId"], self.today["Y-m-d"]
+        )
+        pgThread = rbdb.db_qry(pgq, closeAfter=True, logg=self.log)
+
+        postGameThread = None
+        if len(pgThread) > 0:
+            self.log.info(
+                "Post Game Thread found in database [{}].".format(pgThread[0]["id"])
+            )
+            postGameThread = self.reddit.submission(pgThread[0]["id"])
+            if not postGameThread.author:
+                self.log.warning("Post game thread appears to have been deleted.")
+                q = "update {}threads set deleted=1 where id='{}';".format(
+                    self.dbTablePrefix, postGameThread.id
+                )
+                u = rbdb.db_qry(q, commit=True, closeAfter=True, logg=self.log)
+                if isinstance(u, str):
+                    self.log.error(
+                        "Error marking thread as deleted in database: {}".format(u)
+                    )
+
+                postGameThread = None
+            else:
+                if postGameThread.selftext.find("\n\n^^^Last ^^^Updated") != -1:
+                    postGameThreadText = postGameThread.selftext[
+                        0 : postGameThread.selftext.find("\n\n^^^Last ^^^Updated:")
+                    ]
+                elif postGameThread.selftext.find("\n\n^^^Posted") != -1:
+                    postGameThreadText = postGameThread.selftext[
+                        0 : postGameThread.selftext.find("\n\n^^^Posted:")
+                    ]
+                else:
+                    postGameThreadText = postGameThread.selftext
+
+                self.threadCache["post"].update(
+                    {
+                        "thread": postGameThread,
+                        "text": postGameThreadText,
+                        "title": postGameThread.title
+                        if postGameThread not in [None, False]
+                        else None,
+                    }
+                )
+                # Only sticky when posting the thread
+                # if self.settings.get('Reddit',{}).get('STICKY',False): self.sticky_thread(self.threadCache["post"]["thread"])
+
+        if not postGameThread:
+            # Submit post game thread
+            (postGameThread, postGameThreadText) = self.prep_and_post(
+                "post",
+                postFooter="""
+
+^^^Posted: ^^^"""
+                + self.convert_timezone(
+                    datetime.utcnow(),
+                    self.settings.get("Bot", {}).get(
+                        "TEAM_TIMEZONE", "America/New_York"
+                    ),
+                ).strftime("%m/%d/%Y ^^^%I:%M:%S ^^^%p ^^^%Z"),
+            )
+            self.threadCache["post"].update(
+                {
+                    "thread": postGameThread,
+                    "text": postGameThreadText,
+                    "title": postGameThread.title
+                    if postGameThread not in [None, False]
+                    else None,
+                }
+            )
+            if not postGameThread:
+                self.log.info("Post game thread not posted. Ending update loop...")
+                self.stopFlags.update({"post": True})
+                return  # TODO: Determine why thread is not posted and retry for temporary issue
+
+            skipFlag = True  # No need to edit since the thread was just posted
+
+        while (
+            not self.stopFlags["post"] and redball.SIGNAL is None and not self.bot.STOP
+        ):
+            # Keep the thread updated until stop threshold is reached
+            if skipFlag:
+                skipFlag = None
+                self.log.debug("Skipping edit for post game thread per skip flag...")
+            else:
+                try:
+                    # Update data
+                    self.collect_data()
+                    text = self.render_template(
+                        thread="post",
+                        templateType="thread",
+                        data=self.allData,
+                        settings=self.settings,
+                    )
+                    self.log.debug(f"Rendered post game thread text: {text}")
+                    if text != self.threadCache["post"]["text"] and text != "":
+                        self.threadCache["post"]["text"] = text
+                        text += """
+
+^^^Last ^^^Updated: ^^^""" + self.convert_timezone(
+                            datetime.utcnow(),
+                            self.settings.get("Bot", {}).get(
+                                "TEAM_TIMEZONE", "America/New_York"
+                            ),
+                        ).strftime(
+                            "%m/%d/%Y ^^^%I:%M:%S ^^^%p ^^^%Z"
+                        )
+                        self.threadCache["post"]["thread"].edit(text)
+                        self.log.info("Post game thread edits submitted.")
+                        self.log_last_updated_date_in_db(
+                            self.threadCache["post"]["thread"].id
+                        )
+                        self.count_check_edit(
+                            self.threadCache["post"]["thread"].id,
+                            self.allData["todayGames"][self.allData["myGameIndex"]][
+                                "gameStatus"
+                            ]["phase"],
+                            edit=True,
+                        )
+                    elif text == "":
+                        self.log.info(
+                            "Skipping post game thread edit since thread text is blank..."
+                        )
+                    else:
+                        self.log.info("No changes to post game thread.")
+                        self.count_check_edit(
+                            self.threadCache["post"]["thread"].id,
+                            self.allData["todayGames"][self.allData["myGameIndex"]][
+                                "gameStatus"
+                            ]["phase"],
+                            edit=False,
+                        )
+                except Exception as e:
+                    self.log.error("Error editing post game thread: {}".format(e))
+                    self.error_notification("Error editing post game thread")
+
+            update_postgame_thread_until = self.settings.get(
+                "Post Game Thread", {}
+            ).get("UPDATE_UNTIL", "An hour after thread is posted")
+            if update_postgame_thread_until not in [
+                "Do not update",
+                "An hour after thread is posted",
+                "All division games are final",
+                "All NFL games are final",
+            ]:
+                # Unsupported value, use default
+                self.log.warning(
+                    "Unsupported value detected for Post Game Thread > UPDATE_UNTIL. Using default: An hour after thread is posted."
+                )
+                update_postgame_thread_until = "An hour after thread is posted"
+
+            if update_postgame_thread_until == "Do not update":
+                # Setting says not to update
+                self.log.info(
+                    "Stopping post game thread update loop per UPDATE_UNTIL setting."
+                )
+                self.stopFlags.update({"post": True})
+                break
+            elif update_postgame_thread_until == "An hour after thread is posted":
+                self.log.debug(
+                    f'Thread posted: {int(self.threadCache["post"]["thread"].created_utc)}, 1 hour ago: {round(time.time()) - 3600}, minutes to go: {round((time.time() - int(self.threadCache["post"]["thread"].created_utc)) / 60)}'
+                )
+                if (
+                    int(self.threadCache["post"]["thread"].created_utc)
+                    <= int(time.time()) - 3600
+                ):
+                    # Post game thread was posted more than an hour ago
+                    self.log.info(
+                        "Post game thread was posted an hour ago. Stopping post game thread update loop per UPDATE_UNTIL setting."
+                    )
+                    self.stopFlags.update({"post": True})
+                    break
+            elif update_postgame_thread_until == "All division games are final":
+                if (  # This game is final
+                    self.allData["todayGames"][self.allData["myGameIndex"]][
+                        "gameStatus"
+                    ]["phase"]
+                    in ["FINAL", "FINAL_OVERTIME", "SUSPENDED", "CANCELED", "CANCELLED"]
+                ) and not next(  # And all division games are final
+                    (
+                        True
+                        for x in self.allData["todayGames"]
+                        if x["gameStatus"]["phase"] in ["PREGAME", "INGAME", "HALFTIME"]
+                        and any(
+                            (
+                                True
+                                for divTeamId in self.otherDivisionTeams
+                                if divTeamId["id"]
+                                in [x["visitorTeam"]["id"], x["homeTeam"]["id"]]
+                            )
+                        )
+                    ),
+                    False,
+                ):
+                    # Division games are all final
+                    self.log.info(
+                        "All division games are final. Stopping post game thread update loop per UPDATE_UNTIL setting."
+                    )
+                    self.stopFlags.update({"post": True})
+                    break
+            elif update_postgame_thread_until == "All NFL games are final":
+                if not next(  # All NFL games are final
+                    (
+                        True
+                        for x in self.allData["todayGames"]
+                        if x["gameStatus"]["phase"] in ["PREGAME", "INGAME", "HALFTIME"]
+                    ),
+                    False,
+                ):
+                    # NFL games are all final
+                    self.log.info(
+                        "All NFL games are final. Stopping post game thread update loop per UPDATE_UNTIL setting."
+                    )
+                    self.stopFlags.update({"post": True})
+                    break
+
+            # Update interval is in minutes (seconds for game thread only)
+            pgtWait = self.settings.get("Post Game Thread", {}).get(
+                "UPDATE_INTERVAL", 5
+            )
+            if pgtWait < 1:
+                pgtWait = 1
+            self.log.info(
+                "Post game thread update threshold ({}) not yet reached. Sleeping for {} minute(s)...".format(
+                    update_postgame_thread_until, pgtWait
+                )
+            )
+            self.sleep(pgtWait * 60)
+
+        if redball.SIGNAL is not None or self.bot.STOP:
+            self.log.debug("Caught a stop signal...")
+            return
+
+        # Mark post game thread as stale if sticky is enabled
+        if postGameThread:
+            self.staleThreads.append(postGameThread)
+        self.log.debug("Ending post game update thread...")
+        return  # All done with this game!
+
+    def collect_data(self):
+        """Collect data to be available for template rendering
+        """
+        with DATA_LOCK:
+            # Need to use cached data because multiple threads will be trying to update the same data at the same time
+            cache_seconds = self.settings.get("NFL", {}).get("API_CACHE_SECONDS", 5)
+            if cache_seconds < 0:
+                cache_seconds = 5  # Use default of 5 seconds if negative value provided
+
+            if self.allData.get(
+                "lastUpdate", datetime.today() - timedelta(hours=1)
+            ) >= datetime.today() - timedelta(seconds=cache_seconds):
+                self.log.debug(
+                    "Using cached data, updated {} seconds ago.".format(
+                        (datetime.today() - self.allData["lastUpdate"]).total_seconds(),
+                    )
+                )
+                return False
+            else:
+                self.log.debug(f"Collecting data with nflapi v{nflapi.__version__}")
+
+            # Collect the data...
+            currentWeekGames = self.nfl.gamesByWeek(
+                season=self.allData["currentWeek"]["season"],
+                week=self.allData["currentWeek"]["week"],
+                seasonType=self.allData["currentWeek"]["seasonType"],
+            )["data"]
+            todayGames = [
+                g
+                for g in currentWeekGames
+                if datetime.fromisoformat(g["gameTime"]).strftime("%Y-%m-%d")
+                == self.today["Y-m-d"]
+            ]
+            myGameIndex = next(
+                (
+                    k
+                    for k, v in enumerate(todayGames)
+                    if v["id"] == self.allData["gameId"]
+                ),
+                None,
+            )
+            self.log.debug(
+                f"self.allData['gameDetailId']: {self.allData['gameDetailId']}; self.allData['gameId']: {self.allData['gameId']}; "
+            )
+            gameDetails = (
+                self.nfl.gameDetails(
+                    gameDetailId=self.allData["gameDetailId"]
+                )["data"]["viewer"]["gameDetail"]
+                if self.allData["gameDetailId"]
+                else {}
+            )
+            gameInsights = self.nfl.gameInsights(gameId=self.allData["gameId"])["data"][
+                "viewer"
+            ]["gameInsight"]["insightsByGames"]
+            gameTime = next(
+                (
+                    g["gameTime"]
+                    for g in todayGames
+                    if g["id"] == self.allData["gameId"]
+                ),
+                None,
+            )
+            self.log.debug(f"gameTime: {gameTime}")
+            gameStats = self.nfl.gameStats(
+                gameId=self.allData["gameId"],
+                teamId=todayGames[myGameIndex][
+                    "visitorTeam"
+                    if self.allData["homeVisitor"] == "visitor"
+                    else "homeTeam"
+                ]["id"],
+            )["data"]["viewer"]["stats"]["teamGameStats"]["edges"]
+            gameStats = gameStats[0]["node"] if len(gameStats) else {}
+            standings = self.nfl.standings(
+                season=self.allData["currentWeek"]["season"],
+                seasonType=self.allData["currentWeek"]["seasonType"],
+            )["data"]
+            self.allData.update(
+                {
+                    "myTeam": self.nfl.teamById(teamId=todayGames[myGameIndex][self.allData["homeVisitor"] + "Team"]["id"]),
+                    "oppTeam": self.nfl.teamById(teamId=self.allData["oppTeam"]["id"]),
+                    "gameDetails": gameDetails,
+                    "gameInsights": gameInsights,
+                    "gameStats": gameStats,
+                    "currentWeekGames": currentWeekGames,
+                    "todayGames": todayGames,
+                    "gameTime": {
+                        "homeTeam": datetime.fromisoformat(gameTime),
+                        "bot": self.convert_timezone(
+                            datetime.fromisoformat(gameTime), "local",
+                        ),
+                        "myTeam": self.convert_timezone(
+                            datetime.fromisoformat(gameTime),
+                            self.settings.get("Bot", {}).get(
+                                "TEAM_TIMEZONE", "America/New_York"
+                            ),
+                        ),
+                    },
+                    "myGameIndex": myGameIndex,
+                    "standings": standings,
+                    "lastUpdate": datetime.today(),
+                }
+            )
+
+        if redball.DEV:
+            self.log.debug(
+                "Data available for threads: {}".format(self.allData)
+            )  # debug
+
+        return True
+
+    def log_last_updated_date_in_db(self, threadId, t=None):
+        # threadId = Reddit thread id that was edited, t = timestamp of edit
+        q = "update {}threads set dateUpdated=? where id=?;".format(self.dbTablePrefix)
+        if not t:
+            t = time.time()
+        localArgs = (t, threadId)
+        i = rbdb.db_qry((q, localArgs), commit=True, closeAfter=True, logg=self.log)
+        if isinstance(i, str):
+            self.log.error("Error updating thread edit date in database: {}".format(i))
+            return False
+        else:
+            return True
+
+    def insert_thread_to_db(self, pk, threadId, type):
+        # pk = gameId (or list of gameIds), threadId = thread object returned from Reddit (OFF+date for off day threads), type = ['tailgate', 'game', 'post']
+        q = "insert or ignore into {}threads (gameId, type, gameDate, id, dateCreated, dateUpdated) values".format(
+            self.dbTablePrefix
+        )
+        if isinstance(pk, list):
+            for k in pk:
+                if q[:-1] == ")":
+                    q += ","
+                q += " ('{}', '{}', '{}', '{}', {}, {})".format(
+                    k, type, self.today["Y-m-d"], threadId, time.time(), time.time()
+                )
+        else:
+            q += " ('{}', '{}', '{}', '{}', {}, {})".format(
+                pk, type, self.today["Y-m-d"], threadId, time.time(), time.time()
+            )
+
+        q += ";"
+        i = rbdb.db_qry(q, commit=True, closeAfter=True, logg=self.log)
+        if isinstance(i, str):
+            self.log.error("Error inserting thread into database: {}".format(i))
+            return False
+        else:
+            return True
+
+    def count_check_edit(self, threadId, status, edit=False):
+        # threadId = reddit thread id, status = game status (statusCode, code for detailed state)
+        sq = "select checks,edits from {}thread_edits where threadId='{}' and status='{}';".format(
+            self.dbTablePrefix, threadId, status
+        )
+        s = rbdb.db_qry(sq, closeAfter=True, logg=self.log)
+        if isinstance(s, str):
+            # Error querying for existing row
+            self.log.error(
+                "Error querying for existing row in {}thread_edits table for threadId {} and status {}: {}".format(
+                    self.dbTablePrefix, threadId, status, s
+                )
+            )
+            return False
+        elif s != []:
+            # Row already exists; increment edit count
+            q = "update {}thread_edits set checks=checks+1,{} dateUpdated='{}' where threadId='{}' and status='{}';".format(
+                self.dbTablePrefix,
+                " edits=edits+1," if edit else "",
+                time.time(),
+                threadId,
+                status,
+            )
+        else:
+            # Row does not exist; insert it
+            q = "insert into {}thread_edits (threadId, status, checks, edits, dateCreated, dateUpdated) values ('{}', '{}', {}, {}, '{}', '{}');".format(
+                self.dbTablePrefix,
+                threadId,
+                status,
+                1,
+                1 if edit else 0,
+                time.time(),
+                time.time(),
+            )
+
+        r = rbdb.db_qry(q, commit=True, closeAfter=True, logg=self.log)
+        if isinstance(r, str):
+            # Error inserting/updating row
+            self.log.error(
+                "Error inserting/updating row in {}thread_edits table for threadId {} and status {}: {}".format(
+                    self.dbTablePrefix, threadId, status, r
+                )
+            )
+            return False
+
+        return True
+
+    def prep_and_post(self, thread, postFooter=None):
+        # thread = ['tailgate', 'game', 'post']
+        # postFooter = text to append to post body, but not to include in return text value
+        #   (normally contains a timestamp that would prevent comparison next time to check for changes)
+
+        self.collect_data()
+
+        try:
+            title = self.render_template(
+                thread=thread,
+                templateType="title",
+                data=self.allData,
+                settings=self.settings,
+            )
+            self.log.debug("Rendered {} title: {}".format(thread, title))
+        except Exception as e:
+            self.log.error("Error rendering {} title: {}".format(thread, e))
+            title = None
+            self.error_notification(f"Error rendering title for {thread} thread")
+
+        sticky = self.settings.get("Reddit", {}).get("STICKY", False) is True
+        inboxReplies = (
+            self.settings.get("Reddit", {}).get("INBOX_REPLIES", False) is True
+        )
+        flairMode = self.settings.get("Reddit", {}).get("FLAIR_MODE", "none")
+        flair = (
+            self.settings.get("Tailgate Thread", {}).get("FLAIR", "")
+            if thread == "tailgate"
+            else self.settings.get("Game Thread", {}).get("FLAIR", "")
+            if thread == "game"
+            else self.settings.get("Post Game Thread", {}).get("FLAIR", "")
+            if thread == "post"
+            else ""
+        )
+        sort = (
+            self.settings.get("Tailgate Thread", {}).get("SUGGESTED_SORT", "new")
+            if thread == "tailgate"
+            else self.settings.get("Game Thread", {}).get("SUGGESTED_SORT", "new")
+            if thread == "game"
+            else self.settings.get("Post Game Thread", {}).get("SUGGESTED_SORT", "new")
+            if thread == "post"
+            else "new"
+        )
+        liveDiscussion = (
+            self.settings.get("Tailgate Thread", {}).get("LIVE_DISCUSSION", False)
+            if thread == "tailgate"
+            else self.settings.get("Game Thread", {}).get("LIVE_DISCUSSION", False)
+            if thread == "game"
+            else self.settings.get("Post Game Thread", {}).get("LIVE_DISCUSSION", False)
+            if thread == "post"
+            else False
+        )
+        lockPrevious = (
+            False if thread == "tailgate"
+            else self.settings.get("Game Thread", {}).get("LOCK_TAILGATE_THREAD", False)
+            if thread == "game"
+            else self.settings.get("Post Game Thread", {}).get("LOCK_GAME_THREAD", False)
+            if thread == "post"
+            else False
+        )
+
+        # Check if post already exists
+        theThread = None
+        text = ""
+        try:
+            for p in self.subreddit.new():
+                if p.author == self.reddit.user.me() and p.title == title:
+                    # Found existing thread...
+                    self.log.info("Found an existing {} thread...".format(thread))
+                    theThread = p
+                    if theThread.selftext.find("\n\n^^^Last ^^^Updated") != -1:
+                        text = theThread.selftext[
+                            0 : theThread.selftext.find("\n\n^^^Last ^^^Updated:")
+                        ]
+                    elif theThread.selftext.find("\n\n^^^Posted") != -1:
+                        text = theThread.selftext[
+                            0 : theThread.selftext.find("\n\n^^^Posted:")
+                        ]
+                    else:
+                        text = theThread.selftext
+
+                    if sticky:
+                        self.sticky_thread(theThread)
+
+                    break
+        except Exception as e:
+            self.log.error("Error checking subreddit for existing posts: {}".format(e))
+            self.error_notification("Error checking subreddit for existing posts")
+
+        if not theThread:
+            try:
+                text = self.render_template(
+                    thread=thread,
+                    templateType="thread",
+                    data=self.allData,
+                    settings=self.settings,
+                )
+                self.log.debug("Rendered {} text: {}".format(thread, text))
+            except Exception as e:
+                self.log.error("Error rendering {} text: {}".format(thread, e))
+                text = None
+                self.error_notification(
+                    f"{thread.title()} thread not posted due to failure rendering title or text."
+                )
+
+            if not (title and text):
+                self.log.error(
+                    "Thread not posted due to failure rendering title or text."
+                )
+                return (None, text)
+
+            fullText = text + (postFooter if isinstance(postFooter, str) else "")
+
+            # Submit thread
+            try:
+                theThread = self.submit_reddit_post(
+                    title=title,
+                    text=fullText,
+                    inboxReplies=inboxReplies,
+                    sticky=sticky,
+                    flairMode=flairMode,
+                    flair=flair,
+                    sort=sort,
+                    live_discussion=liveDiscussion,
+                )
+                self.log.info("Submitted {} thread: ({}).".format(thread, theThread))
+            except Exception as e:
+                self.log.error("Error submitting {} thread: {}".format(thread, e))
+                theThread = None
+                self.error_notification(f"Error submitting {thread} thread")
+
+        if theThread:
+            self.log.debug(
+                "Inserting {} thread into DB for game {}...".format(
+                    thread, self.allData["gameId"]
+                )
+            )
+            self.insert_thread_to_db(self.allData["gameId"], theThread, thread)
+
+            # Check for webhooks
+            for w in range(0, 10):
+                s = "" if w == 0 else str(w)
+                webhook_url = (
+                    self.settings.get("Tailgate Thread", {}).get(
+                        "WEBHOOK{}_URL".format(s)
+                    )
+                    if thread == "tailgate"
+                    else self.settings.get("Game Thread", {}).get(
+                        "WEBHOOK{}_URL".format(s)
+                    )
+                    if thread == "game"
+                    else self.settings.get("Post Game Thread", {}).get(
+                        "WEBHOOK{}_URL".format(s)
+                    )
+                    if thread == "post"
+                    else None
+                )
+                if webhook_url:
+                    self.log.debug(
+                        "Webhook{} URL for {} thread: [{}].".format(
+                            s, thread, webhook_url
+                        )
+                    )
+                    webhook_text = self.render_template(
+                        thread=thread,
+                        templateType="webhook" + s,
+                        data=self.allData,
+                        settings=self.settings,
+                        theThread=theThread,
+                    )
+                    self.log.debug(
+                        "Rendered {} webhook{} text: {}".format(thread, s, webhook_text)
+                    )
+                    if webhook_text:
+                        webhook_result = self.post_webhook(webhook_url, webhook_text)
+                        self.log.info(
+                            "Webhook [{}] result: {}.".format(
+                                webhook_url,
+                                webhook_result
+                                if isinstance(webhook_result, str)
+                                else "success",
+                            )
+                        )
+                else:
+                    # Break the loop if no more webhook urls configured
+                    break
+
+            # Check for Prowl notification
+            prowlKey = self.settings.get("Prowl", {}).get("THREAD_POSTED_API_KEY", "")
+            prowlPriority = self.settings.get("Prowl", {}).get(
+                "THREAD_POSTED_PRIORITY", ""
+            )
+            if prowlKey == "" or prowlPriority == "":
+                self.log.debug("Prowl notifications are disabled or not configured.")
+            else:
+                self.notify_prowl(
+                    apiKey=prowlKey,
+                    event=f"{self.myTeam['teamName']} {thread.title()} Thread Posted",
+                    description=f"""{self.myTeam['teamName']} {thread} thread was posted to r/{self.settings["Reddit"]["SUBREDDIT"]} at {self.convert_timezone(datetime.utcfromtimestamp(theThread.created_utc),'local').strftime('%I:%M %p %Z')}\nThread title: {theThread.title}\nURL: {theThread.shortlink}""",
+                    priority=prowlPriority,
+                    url=theThread.shortlink,
+                    appName=f"redball - {self.bot.name}",
+                )
+
+            # Check for Twitter
+            tConsumerKey = self.settings.get("Twitter", {}).get("CONSUMER_KEY", "")
+            tConsumerSecret = self.settings.get("Twitter", {}).get(
+                "CONSUMER_SECRET", ""
+            )
+            tAccessToken = self.settings.get("Twitter", {}).get("ACCESS_TOKEN", "")
+            tAccessSecret = self.settings.get("Twitter", {}).get("ACCESS_SECRET", "")
+            tweetThreadPosted = self.settings.get("Twitter", {}).get(
+                "TWEET_THREAD_POSTED", False
+            )
+            if (
+                "" in [tConsumerKey, tConsumerSecret, tAccessToken, tAccessSecret]
+                or not tweetThreadPosted
+            ):
+                self.log.debug("Twitter disabled or not configured")
+            else:
+                if thread == "game":
+                    message = f"""{theThread.title} - Join the discussion: {theThread.shortlink} #{self.myTeam['teamName'].replace(' ','')}"""
+                elif thread == "tailgate":
+                    message = f"""{theThread.title} - Join the discussion: {theThread.shortlink} #{self.myTeam['teamName'].replace(' ','')}"""
+                elif thread == "post":
+                    message = f"""{theThread.title} - The discussion continues: {theThread.shortlink} #{self.myTeam['teamName'].replace(' ','')}"""
+                else:
+                    self.log.error(f"Can't tweet about unknown thread type [{thread}]!")
+                    return (None, text)
+
+                tweetResult = self.tweet_thread(
+                    message=message,
+                    consumerKey=tConsumerKey,
+                    consumerSecret=tConsumerSecret,
+                    accessToken=tAccessToken,
+                    accessSecret=tAccessSecret,
+                )
+                if tweetResult:
+                    self.log.info("Tweet submitted successfully!")
+
+            # Lock previous thread
+            if lockPrevious:
+                if threadToLock := (
+                    self.threadCache["tailgate"].get("thread")
+                    if thread == "game"
+                    else self.threadCache["game"].get("thread")
+                    if thread == "post"
+                    else None
+                ):
+                    commentText = (
+                        self.settings.get("Game Thread", {}).get("LOCK_MESSAGE", None)
+                        if thread == "game"
+                        else self.settings.get("Post Game Thread", {}).get("LOCK_MESSAGE", None)
+                        if thread == "post"
+                        else None
+                    )
+                    if not commentText:
+                        commentText = f"This thread has been locked. Please continue the discussion in the [{'game' if thread == 'game' else 'post game' if thread == 'post' else 'new'} thread](link)."
+                    parsedCommentText = commentText.replace("(link)", f"({theThread.shortlink})")
+                    try:
+                        self.log.debug(f"Attempting to lock {'tailgate' if thread == 'game' else 'game' if thread == 'post' else ''} thread [{threadToLock.id}]...")
+                        threadToLock.mod.lock()
+                        self.log.debug("Submitting comment with link to new thread...")
+                        lockReply = threadToLock.reply(parsedCommentText)
+                        self.log.debug("Distinguishing comment...")
+                        lockReply.mod.distinguish(sticky=True)
+                        self.log.debug("Successfully locked thread and posted a distinguished/sticky reply.")
+                    except Exception as e:
+                        self.log.warning(f"Failed to lock {'tailgate' if thread == 'game' else 'game' if thread == 'post' else ''} thread [{threadToLock.id}], submit reply with link to new thread, or distinguish and sticky comment: {e}")
+                else:
+                    self.log.debug("I did not find a previous thread to lock.")
+        else:
+            self.log.warning("No thread object present. Something went wrong!")
+
+        return (theThread, text)
+
+    def tweet_thread(
+        self,
+        message,
+        consumerKey=None,
+        consumerSecret=None,
+        accessToken=None,
+        accessSecret=None,
+    ):
+        if not consumerKey or not consumerSecret or not accessToken or not accessSecret:
+            self.log.warning(
+                "Can't submit tweet because Twitter settings are missing or incomplete. Check bot config."
+            )
+            return False
+
+        self.log.debug("Initiating Twitter...")
+        try:
+            t = twitter.Api(consumerKey, consumerSecret, accessToken, accessSecret)
+            self.log.debug(
+                f"Authenticated Twitter user: {t.VerifyCredentials().screen_name}"
+            )
+            self.log.debug(f"Tweeting: {message}")
+            t.PostUpdate(message)
+            return True
+        except Exception as e:
+            self.log.error(f"Error submitting Tweet: {e}")
+            self.error_notification(f"Error submitting Tweet: {e}")
+            return False
+
+    def notify_prowl(
+        self, apiKey, event, description, priority=0, url=None, appName="redball"
+    ):
+        # Send a notification to Prowl
+        p = pyprowl.Prowl(apiKey=apiKey, appName=appName)
+
+        self.log.debug(
+            f"Sending notification to Prowl with API Key: {apiKey}. Event: {event}, Description: {description}, Priority: {priority}, URL: {url}..."
+        )
+        try:
+            p.notify(
+                event=event, description=description, priority=priority, url=url,
+            )
+            self.log.info("Notification successfully sent to Prowl!")
+            return True
+        except Exception as e:
+            self.log.error("Error sending notification to Prowl: {}".format(e))
+            return False
+
+    def error_notification(self, action):
+        # Generate and send notification to Prowl for errors
+        prowlKey = self.settings.get("Prowl", {}).get("ERROR_API_KEY", "")
+        prowlPriority = self.settings.get("Prowl", {}).get("ERROR_PRIORITY", "")
+        newline = "\n"
+        if prowlKey != "" and prowlPriority != "":
+            self.notify_prowl(
+                apiKey=prowlKey,
+                event=f"{self.bot.name} - {action}!",
+                description=f"{action} for bot: [{self.bot.name}]!\n\n{newline.join(traceback.format_exception(*sys.exc_info()))}",
+                priority=prowlPriority,
+                appName=f"redball - {self.bot.name}",
+            )
+
+    def post_webhook(self, url, body):
+        # url = url to which the data should be posted
+        # body = dict or json-formatted string of data to post to the webhook url
+        if isinstance(body, str):
+            # We need the data to be a dict rather than json
+            # so we can use the json param of requests.post().
+            # Otherwise we have to set headers and stuff
+            try:
+                body = json.loads(body)
+            except Exception as e:
+                self.log.error(
+                    "Failed to convert webhook template from json format. Ensure there are no line breaks or other special characters in the rendered template. Error: {}".format(
+                        e
+                    )
+                )
+                self.error_notification(
+                    "Failed to convert webhook template from json format. Ensure there are no line breaks or other special characters in the rendered template"
+                )
+                return "Failed to convert webhook template from json format. Ensure there are no line breaks or other special characters in the rendered template. Error: {}".format(
+                    e
+                )
+
+        try:
+            r = requests.post(url, json=body)
+            if r.status_code in [200, 204]:
+                return True
+            else:
+                return "Request status code: {}".format(r.status_code)
+        except requests.exceptions.RequestException as e:
+            self.error_notification(f"Error posting to webhook [{url}]")
+            return str(e)
+
+        return False
+
+    def submit_reddit_post(
+        self,
+        title,
+        text,
+        sub=None,
+        inboxReplies=False,
+        sticky=False,
+        flairMode=None,
+        flair=None,
+        sort=None,
+        live_discussion=False,
+    ):
+        if sub:
+            subreddit = self.reddit.subreddit(sub)
+        else:
+            subreddit = self.subreddit
+
+        post = subreddit.submit(
+            title=title,
+            selftext=text,
+            send_replies=inboxReplies,
+            discussion_type="CHAT" if live_discussion else None,
+        )
+        self.log.info("Thread ({}) submitted: {}".format(title, post))
+
+        if sticky:
+            self.sticky_thread(post)
+
+        if flairMode == "submitter":
+            if flair in [None, ""]:
+                self.log.warning("FLAIR_MODE = submitter, but no flair provided...")
+            else:
+                self.log.info("Adding flair to submission as submitter...")
+                choices = post.flair.choices()
+                flairsuccess = False
+                for p in choices:
+                    if p["flair_text"] == flair:
+                        post.flair.select(p["flair_template_id"])
+                        flairsuccess = True
+                if flairsuccess:
+                    self.log.info("Submission flaired...")
+                else:
+                    self.log.error(
+                        "Flair not set: could not find flair in available choices; check subreddit configuration."
+                    )
+        elif flairMode == "mod":
+            if flair in [None, ""]:
+                self.log.warning("FLAIR_MODE = mod, but no flair provided...")
+            else:
+                self.log.info("Adding flair to submission as mod...")
+                try:
+                    post.mod.flair(flair)
+                    self.log.info("Submission flaired...")
+                except Exception:
+                    self.log.error(
+                        "Failed to set flair on thread {post.id} (check mod privileges or change FLAIR_MODE to submitter), continuing..."
+                    )
+                    self.error_notification(
+                        "Failed to set flair (check mod privileges or change FLAIR_MODE to submitter)"
+                    )
+
+        if sort not in [None, ""]:
+            self.log.info("Setting suggested sort to {}...".format(sort))
+            try:
+                post.mod.suggested_sort(sort)
+                self.log.info("Suggested sort set...")
+            except Exception:
+                self.log.error(
+                    "Setting suggested sort failed (check mod privileges), continuing..."
+                )
+                self.error_notification(
+                    f"Failed to set suggested sort on thread {post.id} (check mod privileges)"
+                )
+
+        return post
+
+    def render_template(self, thread, templateType, **kwargs):
+        setting = "{}_TEMPLATE".format(templateType.upper())
+        templateFilename = (
+            self.settings.get("Tailgate Thread", {}).get(setting, "")
+            if thread == "tailgate"
+            else self.settings.get("Game Thread", {}).get(setting, "")
+            if thread == "game"
+            else self.settings.get("Post Game Thread", {}).get(setting, "")
+            if thread == "post"
+            else ""
+        )
+        self.log.debug(f"templateFilename: {templateFilename}")
+        try:
+            template = self.LOOKUP.get_template(templateFilename)
+            return template.render(**kwargs)
+        except Exception:
+            self.log.error(
+                "Error rendering template [{}] for {} {}. Falling back to default template. Error: {}".format(
+                    templateFilename,
+                    thread,
+                    templateType,
+                    mako.exceptions.text_error_template().render(),
+                )
+            )
+            self.error_notification(
+                f"Error rendering {thread} {templateType} template [{templateFilename}]"
+            )
+            try:
+                template = self.LOOKUP.get_template(
+                    "{}_{}.mako".format(thread, templateType)
+                )
+                return template.render(**kwargs)
+            except Exception:
+                self.log.error(
+                    "Error rendering default template for thread [{}] and type [{}]: {}".format(
+                        thread,
+                        templateType,
+                        mako.exceptions.text_error_template().render(),
+                    )
+                )
+                self.error_notification(
+                    f"Error rendering default {thread} {templateType} template [{template.filename}]"
+                )
+
+        return ""
+
+    def sticky_thread(self, thread):
+        self.log.info("Stickying thread [{}]...".format(thread.id))
+        try:
+            thread.mod.sticky()
+            self.log.info("Thread [{}] stickied...".format(thread.id))
+        except Exception:
+            self.log.warning(
+                "Sticky of thread [{}] failed. Check mod privileges or the thread may have already been sticky.".format(
+                    thread.id
+                )
+            )
+
+    def unsticky_threads(self, threads):
+        for t in threads:
+            try:
+                self.log.debug("Attempting to unsticky thread [{}]".format(t.id))
+                t.mod.sticky(state=False)
+            except Exception:
+                self.log.debug(
+                    "Unsticky of thread [{}] failed. Check mod privileges or the thread may not have been sticky.".format(
+                        t.id
+                    )
+                )
+
+    def build_tables(self):
+        queries = []
+        queries.append(
+            """CREATE TABLE IF NOT EXISTS {}games (
+                id integer primary key autoincrement,
+                gameId text unique not null,
+                gameDate text not null,
+                dateAdded text not null
+            );""".format(
+                self.dbTablePrefix
+            )
+        )
+
+        queries.append(
+            """CREATE TABLE IF NOT EXISTS {}threads (
+                gameId integer not null,
+                type text not null,
+                gameDate text not null,
+                id text not null,
+                dateCreated text not null,
+                dateUpdated text not null,
+                deleted integer default 0,
+                unique (gameId, type, id, gameDate, deleted)
+            );""".format(
+                self.dbTablePrefix
+            )
+        )
+
+        queries.append(
+            """CREATE TABLE IF NOT EXISTS {}thread_edits (
+                threadId text not null,
+                status text not null,
+                checks integer default 0,
+                edits integer default 0,
+                dateCreated text not null,
+                dateUpdated text not null,
+                unique (threadId, status)
+            );""".format(
+                self.dbTablePrefix
+            )
+        )
+
+        self.log.debug(
+            "Executing queries to build {} tables: {}".format(len(queries), queries)
+        )
+        results = rbdb.db_qry(queries, commit=True, closeAfter=True, logg=self.log)
+        if None in results:
+            self.log.debug("One or more queries failed: {}".format(results))
+        else:
+            self.log.debug("Building of tables complete. Results: {}".format(results))
+
+        return True
+
+    def refresh_settings(self):
+        self.prevSettings = self.settings
+        self.settings = self.bot.get_config()
+        if self.prevSettings["Logging"] != self.settings["Logging"]:
+            # reload logger
+            self.log = logger.init_logger(
+                logger_name="redball.bots." + threading.current_thread().name,
+                log_to_console=self.settings.get("Logging", {}).get(
+                    "LOG_TO_CONSOLE", True
+                ),
+                log_to_file=self.settings.get("Logging", {}).get("LOG_TO_FILE", True),
+                log_path=redball.LOG_PATH,
+                log_file="{}.log".format(threading.current_thread().name),
+                file_log_level=self.settings.get("Logging", {}).get("FILE_LOG_LEVEL"),
+                console_log_level=self.settings.get("Logging", {}).get(
+                    "CONSOLE_LOG_LEVEL"
+                ),
+                clear_first=True,
+                propagate=False,
+            )
+            self.log.info("Restarted logger with new settings")
+
+        if self.prevSettings["Reddit Auth"] != self.settings["Reddit Auth"]:
+            self.log.info(
+                "Detected new Reddit Authorization info. Re-initializing Reddit API..."
+            )
+            self.init_reddit()
+
+        # Check here if settings have changed for other services added in the future (twitter, etc.)
+
+        self.log.debug("Refreshed settings: {}".format(self.settings))
+
+    def init_reddit(self):
+        self.log.debug(f"Initializing Reddit API with praw v{praw.__version__}...")
+        try:
+            self.reddit = praw.Reddit(
+                client_id=self.settings["Reddit Auth"]["reddit_clientId"],
+                client_secret=self.settings["Reddit Auth"]["reddit_clientSecret"],
+                refresh_token=self.settings["Reddit Auth"]["reddit_refreshToken"],
+                user_agent="redball Football Game Thread Bot - https://github.com/toddrob99/redball/ - r/{}".format(
+                    self.settings["Reddit"].get("SUBREDDIT", "")
+                ),
+            )
+        except Exception as e:
+            self.log.error(
+                "Error encountered attempting to initialize Reddit: {}".format(e)
+            )
+            self.error_notification("Error initializing Reddit")
+            raise
+
+        scopes = [
+            "identity",
+            "submit",
+            "edit",
+            "read",
+            "modposts",
+            "privatemessages",
+            "flair",
+            "modflair",
+        ]
+        try:
+            praw_scopes = self.reddit.auth.scopes()
+        except Exception as e:
+            self.log.error(
+                "Error encountered attempting to look up authorized Reddit scopes: {}".format(
+                    e
+                )
+            )
+            self.error_notification(
+                "Error encountered attempting to look up authorized Reddit scopes"
+            )
+            raise
+
+        missing_scopes = []
+        self.log.debug("Reddit authorized scopes: {}".format(praw_scopes))
+        try:
+            if self.reddit.user.me() is None:
+                raise ValueError(
+                    "Failed to initialize Reddit instance--authorized user is None"
+                )
+            self.log.info("Reddit authorized user: {}".format(self.reddit.user.me()))
+        except Exception as e:
+            self.log.warning(
+                "Error encountered attempting to identify authorized Reddit user (identity scope may not be authorized): {}".format(
+                    e
+                )
+            )
+            self.error_notification(
+                "Error encountered attempting to identify authorized Reddit user (identity scope may not be authorized)"
+            )
+
+        for scope in scopes:
+            if scope not in praw_scopes:
+                missing_scopes.append(scope)
+
+        if len(missing_scopes):
+            self.log.warning(
+                "Scope(s) not authorized: {}. Please check/update/re-authorize Reddit Authorization in redball System Config.".format(
+                    missing_scopes
+                )
+            )
+
+        self.subreddit = self.reddit.subreddit(
+            self.settings.get("Reddit", {}).get("SUBREDDIT")
+        )
+
+    def eod_loop(self, today):
+        # today = date that's already been finished ('%Y-%m-%d')
+        # return when datetime.today().strftime('%Y-%m-%d') is not equal to today param (it's the next day)
+        while redball.SIGNAL is None and not self.bot.STOP:
+            # End of day loop
+            if redball.SIGNAL is not None or self.bot.STOP:
+                break
+            elif today != datetime.today().strftime("%Y-%m-%d"):
+                self.log.info("It's a brand new day!")
+                break
+            else:
+                i = 0
+                while True:
+                    if redball.SIGNAL is None and not self.bot.STOP:
+                        i += 1
+                        if today != datetime.today().strftime("%Y-%m-%d"):
+                            break
+                        elif i == 600:
+                            self.log.info("Still waiting for the next day...")
+                            break
+                        time.sleep(1)
+                    else:
+                        break
+
+    def sleep(self, t):
+        # t = total number of seconds to sleep before returning
+        i = 0
+        while redball.SIGNAL is None and not self.bot.STOP and i < t:
+            i += 1
+            time.sleep(1)
+
+    def convert_timezone(self, dt, convert_to="America/New_York"):
+        # dt = datetime object to convert, convert_to = timezone to convert to (e.g. 'America/New_York', or 'local' for local bot timezone)
+        if not dt.tzinfo:
+            dt = dt.replace(tzinfo=pytz.utc)
+
+        if convert_to == "local":
+            to_tz = tzlocal.get_localzone()
+        else:
+            to_tz = pytz.timezone(convert_to)
+
+        return dt.astimezone(to_tz)
+
+    teamSubs = {
+        "ARI": "r/AZCardinals",
+        "ATL": "r/falcons",
+        "BAL": "r/ravens",
+        "BUF": "r/buffalobills",
+        "CAR": "r/panthers",
+        "CHI": "r/CHIBears",
+        "CIN": "r/bengals",
+        "CLE": "r/Browns",
+        "DAL": "r/cowboys",
+        "DEN": "r/DenverBroncos",
+        "DET": "r/detroitlions",
+        "GB": "r/GreenBayPackers",
+        "HOU": "r/Texans",
+        "IND": "r/Colts",
+        "JAX": "r/Jaguars",
+        "KC": "r/KansasCityChiefs",
+        "LA": "r/LosAngelesRams",
+        "LAC": "r/Chargers",
+        "LV": "r/raiders",
+        "MIA": "r/miamidolphins",
+        "MIN": "r/minnesotavikings",
+        "NE": "r/Patriots",
+        "NO": "r/Saints",
+        "NYG": "r/NYGiants",
+        "NYJ": "r/nyjets",
+        "PHI": "r/eagles",
+        "PIT": "r/steelers",
+        "SEA": "r/Seahawks",
+        "SF": "r/49ers",
+        "TB": "r/buccaneers",
+        "TEN": "r/Tennesseetitans",
+        "WAS": "r/Redskins",
+        0: "r/NFL",
+        "nfl": "r/NFL",
+    }
+
+    def bot_state(self):
+        """Return current state...
+        Current date being monitored
+        Game being monitored with current status
+        Threads pending and post time
+        Threads posted
+        """
+        try:
+            botStatus = {
+                "lastUpdated": datetime.today().strftime("%m/%d/%Y %I:%M:%S %p"),
+                "myTeam": {
+                    "id": self.myTeam["id"],
+                    "fullName": self.myTeam["fullName"],
+                    "abbr": self.myTeam["abbr"],
+                    "nickName": self.myTeam["nickName"],
+                    "cityStateRegion": self.myTeam["cityStateRegion"],
+                },
+                "today": self.today,
+                "currentWeek": self.allData["currentWeek"],
+                "tailgateThread": {
+                    "enabled": self.settings.get("Tailgate Thread", {}).get(
+                        "ENABLED", True
+                    ),
+                    "postTime": self.threadCache.get("tailgate", {})
+                    .get("postTime_local")
+                    .strftime("%m/%d/%Y %I:%M:%S %p")
+                    if isinstance(
+                        self.threadCache.get("tailgate", {}).get("postTime_local"),
+                        datetime,
+                    )
+                    else "",
+                    "posted": True
+                    if self.threadCache.get("tailgate", {}).get("thread")
+                    else False,
+                    "id": self.threadCache.get("tailgate", {}).get("thread").id
+                    if self.threadCache.get("tailgate", {}).get("thread")
+                    else None,
+                    "url": self.threadCache.get("tailgate", {}).get("thread").shortlink
+                    if self.threadCache.get("tailgate", {}).get("thread")
+                    else None,
+                    "title": self.threadCache.get("tailgate", {}).get("title")
+                    if self.threadCache.get("tailgate", {}).get("thread")
+                    else None,
+                },
+                "game": {
+                    "gameId": self.allData.get("gameId"),
+                    "status": self.allData.get("gameDetails", {}).get("phase"),
+                    "oppTeam": self.allData.get("oppTeam"),
+                    "homeVisitor": self.allData.get("homeVisitor"),
+                    "threads": {
+                        "game": {
+                            "enabled": self.settings.get("Game Thread", {}).get(
+                                "ENABLED", True
+                            ),
+                            "postTime": self.threadCache["game"]
+                            .get("postTime_local")
+                            .strftime("%m/%d/%Y %I:%M:%S %p")
+                            if isinstance(
+                                self.threadCache["game"].get("postTime_local"), datetime
+                            )
+                            else "",
+                            "posted": True
+                            if self.threadCache["game"].get("thread")
+                            else False,
+                            "id": self.threadCache["game"].get("thread").id
+                            if self.threadCache["game"].get("thread")
+                            else None,
+                            "url": self.threadCache["game"].get("thread").shortlink
+                            if self.threadCache["game"].get("thread")
+                            else None,
+                            "title": self.threadCache["game"].get("title")
+                            if self.threadCache["game"].get("thread")
+                            else None,
+                        },
+                        "post": {
+                            "enabled": self.settings.get("Post Game Thread", {}).get(
+                                "ENABLED", True
+                            ),
+                            "posted": True
+                            if self.threadCache["post"].get("thread")
+                            else False,
+                            "id": self.threadCache["post"].get("thread").id
+                            if self.threadCache["post"].get("thread")
+                            else None,
+                            "url": self.threadCache["post"].get("thread").shortlink
+                            if self.threadCache["post"].get("thread")
+                            else None,
+                            "title": self.threadCache["post"].get("title")
+                            if self.threadCache["post"].get("thread")
+                            else None,
+                        },
+                    },
+                },
+            }
+
+            botStatus.update(
+                {
+                    "summary": {
+                        "text": "Today is {}.\nCurrent Week: {} {} {}.".format(
+                            botStatus["today"]["Y-m-d"],
+                            botStatus["currentWeek"]["season"],
+                            botStatus["currentWeek"]["seasonType"],
+                            botStatus["currentWeek"]["name"],
+                        ),
+                        "html": "Today is {}.<br />Current Week: {} {} {}.".format(
+                            botStatus["today"]["Y-m-d"],
+                            botStatus["currentWeek"]["season"],
+                            botStatus["currentWeek"]["seasonType"],
+                            botStatus["currentWeek"]["name"],
+                        ),
+                        "markdown": "Today is {}.\n\nCurrent Week: {} {} {}.".format(
+                            botStatus["today"]["Y-m-d"],
+                            botStatus["currentWeek"]["season"],
+                            botStatus["currentWeek"]["seasonType"],
+                            botStatus["currentWeek"]["name"],
+                        ),
+                    }
+                }
+            )
+
+            botStatus["summary"]["text"] += "\n\nLast Updated: {}".format(
+                botStatus["lastUpdated"]
+            )
+            botStatus["summary"][
+                "html"
+            ] += "<br /><br /><strong>Last Updated</strong>: {}".format(
+                botStatus["lastUpdated"]
+            )
+            botStatus["summary"]["markdown"] += "\n\n**Last Updated**: {}".format(
+                botStatus["lastUpdated"]
+            )
+        except Exception as e:
+            botStatus = {
+                "lastUpdated": datetime.today().strftime("%m/%d/%Y %I:%M:%S %p"),
+                "summary": {
+                    "text": "Error retrieving bot state: {}".format(e),
+                    "html": "Error retrieving bot state: {}".format(e),
+                    "markdown": "Error retrieving bot state: {}".format(e),
+                },
+            }
+            self.error_notification("Error retrieving bot state")
+
+        self.log.debug("Bot Status: {}".format(botStatus))  # debug
+        self.bot.detailedState = botStatus
+
+    def isGameCanceled(self, gameInsights):
+        if insight := next(
+            (x for x in gameInsights if "canceled" in x["headline"]), None
+        ):
+            self.log.info(
+                f"Detected that the game is canceled based on the following headline: {insight['headline']}"
+            )
+            return True
+        else:
+            return False
+
+    def getNflToken(self, nflSession=None):
+        self.log.debug("Retrieving fresh NFL API token...")
+        url = "https://api.nfl.com/v1/reroute"
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "x-domain-id": "100",
+        }
+        body = {
+            "grant_type": "client_credentials",
+        }
+
+        try:
+            r = requests.post(url, data=body, headers=headers)
+            content = json.loads(r.content)
+        except Exception as e:
+            self.log.error(f"Caught exception requesting NFL API token: {e}")
+            raise
+
+        if nflSession:
+            # Update existing NFL API session
+            nflSession.token = content
+
+        return content

--- a/bots/nfl_game_threads/templates/division_scoreboard.mako
+++ b/bots/nfl_game_threads/templates/division_scoreboard.mako
@@ -1,0 +1,39 @@
+<%
+    from datetime import datetime
+    import pytz
+    gameStatusDesc = {
+        "PREGAME": "Pre",
+        "INGAME": "Live",
+        "HALFTIME": "Half",
+        "SUSPENDED": "Susp",
+        "FINAL": "Final",
+        "FINAL_OVERTIME": "F/OT",
+    }
+    qtrDesc = {
+        1: "Q1",
+        2: "Q2",
+        3: "Q3",
+        4: "Q4",
+        5: "OT",
+        6: "OT2",
+        7: "OT3",
+        8: "OT4",
+        9: "OT5",
+        10: "OT6",
+    }
+    divGames = [x for x in data["todayGames"] if data["myTeam"]["division"]["abbr"] in [x["visitorTeam"]["division"]["abbr"], x["homeTeam"]["division"]["abbr"]] and data["myTeam"]["id"] not in [x["visitorTeam"]["id"], x["homeTeam"]["id"]]]
+%>\
+% if len(divGames):
+${'##'} Division Scoreboard
+% for game in divGames:
+<%
+    dt = datetime.fromisoformat(game["gameTime"])
+    toTz = pytz.timezone(settings.get("Bot", {}).get("TEAM_TIMEZONE", "America/New_York"))
+    formattedGameTime = dt.astimezone(toTz).strftime("%I:%M %p")
+%>\
+|${qtrDesc[game["gameStatus"]["period"]] if game["gameStatus"]["period"] else ""} ${game["gameStatus"]["gameClock"] if game["gameStatus"]["phase"] == "INGAME" else gameStatusDesc[game["gameStatus"]["phase"]] if game["gameStatus"]["phase"] != "PREGAME" else formattedGameTime}||
+|:--|:--|
+|${game["visitorTeam"]["abbr"]}${" &#127944;" if game["gameStatus"]["possessionTeam"] and game["gameStatus"]["possessionTeam"]["id"] == game["visitorTeam"]["id"] else ""}|${game['visitorTeamScore'].get('pointsTotal', 0) if game["gameStatus"]["phase"] != "PREGAME" else ""}|
+|${game["homeTeam"]["abbr"]}${" &#127944;" if game["gameStatus"]["possessionTeam"] and game["gameStatus"]["possessionTeam"]["id"] == game["homeTeam"]["id"] else ""}|${game['homeTeamScore'].get('pointsTotal', 0) if game["gameStatus"]["phase"] != "PREGAME" else ""}|
+% endfor
+% endif  # if len(divGames)

--- a/bots/nfl_game_threads/templates/game_stats.mako
+++ b/bots/nfl_game_threads/templates/game_stats.mako
@@ -1,0 +1,202 @@
+<%
+    from datetime import timedelta
+    if not len(data["gameStats"]):
+        return
+
+    game = data["todayGames"][data["myGameIndex"]]
+    v = "teamGameStats" if data["homeVisitor"] == "visitor" else "opponentGameStats"
+    h = "opponentGameStats" if v == "teamGameStats" else "opponentGameStats"
+    headerRowTemplate = "|"
+    alignmentRowTemplate = "|:--|"
+    visitorRowTemplate = f'|{game["visitorTeam"]["abbr"]}|'
+    homeRowTemplate = f'|{game["homeTeam"]["abbr"]}|'
+
+    # General table
+    gen_headerRow = headerRowTemplate + "|"
+    gen_alignmentRow = alignmentRowTemplate
+    gen_visitorRow = visitorRowTemplate
+    gen_homeRow = homeRowTemplate
+
+    # Time of possession
+    gen_headerRow += "Time/Poss|"
+    gen_alignmentRow += ":--|"
+    gen_visitorRow += f'{str(timedelta(seconds=data["gameStats"][v]["timeOfPossSeconds"]))[-5:]}|'
+    gen_homeRow += f'{str(timedelta(seconds=data["gameStats"][h]["timeOfPossSeconds"]))[-5:]}|'
+
+    # Total plays
+    gen_headerRow += "Plays (Yds)|"
+    gen_alignmentRow += ":--|"
+    gen_visitorRow += f'{data["gameStats"][v]["scrimmagePlays"]} ({data["gameStats"][v]["scrimmageYds"]})|'
+    gen_homeRow += f'{data["gameStats"][h]["scrimmagePlays"]} ({data["gameStats"][h]["scrimmageYds"]})|'
+
+    # Third downs
+    gen_headerRow += "3rd downs (Conv)|"
+    gen_alignmentRow += ":--|"
+    gen_visitorRow += f'{data["gameStats"][v]["down3rdAttempted"]} ({data["gameStats"][v]["down3rdFdMade"]})|'
+    gen_homeRow += f'{data["gameStats"][h]["down3rdAttempted"]} ({data["gameStats"][h]["down3rdFdMade"]})|'
+
+    # Penalties
+    gen_headerRow += "Penalties (Yds)|"
+    gen_alignmentRow += ":--|"
+    gen_visitorRow += f'{data["gameStats"][v]["penaltiesTotal"]} ({data["gameStats"][v]["penaltiesYardsPenalized"]})|'
+    gen_homeRow += f'{data["gameStats"][h]["penaltiesTotal"]} ({data["gameStats"][h]["penaltiesYardsPenalized"]})|'
+
+    # Turnovers
+    gen_headerRow += "Turnovers|"
+    gen_alignmentRow += ":--|"
+    gen_visitorRow += f'{data["gameStats"][v]["fumblesLost"] + data["gameStats"][v]["passingInterceptions"]}|'
+    gen_homeRow += f'{data["gameStats"][h]["fumblesLost"] + data["gameStats"][h]["passingInterceptions"]}|'
+
+    # Passing table
+    pass_headerRow = headerRowTemplate + "Passing|"
+    pass_alignmentRow = alignmentRowTemplate
+    pass_visitorRow = visitorRowTemplate
+    pass_homeRow = homeRowTemplate
+
+    # Pass completions/attempts
+    pass_headerRow += "Comp/Att|"
+    pass_alignmentRow += ":--|"
+    pass_visitorRow += f'{data["gameStats"][v]["passingCompletions"]}/{data["gameStats"][v]["passingAttempts"]}|'
+    pass_homeRow += f'{data["gameStats"][h]["passingCompletions"]}/{data["gameStats"][h]["passingAttempts"]}|'
+
+    # Pass yds
+    pass_headerRow += "Yds Tot/Avg/Lng|"
+    pass_alignmentRow += ":--|"
+    pass_visitorRow += f'{data["gameStats"][v]["passingNetYards"]}/{data["gameStats"][v]["passingAverageYards"]}/{data["gameStats"][v]["passingLong"]}|'
+    pass_homeRow += f'{data["gameStats"][h]["passingNetYards"]}/{data["gameStats"][h]["passingAverageYards"]}/{data["gameStats"][h]["passingLong"]}|'
+
+    # Pass 1st downs
+    pass_headerRow += "1st Dn|"
+    pass_alignmentRow += ":--|"
+    pass_visitorRow += f'{data["gameStats"][v]["passingFirstDowns"]}|'
+    pass_homeRow += f'{data["gameStats"][h]["passingFirstDowns"]}|'
+
+    # Pass TD
+    pass_headerRow += "TD|"
+    pass_alignmentRow += ":--|"
+    pass_visitorRow += f'{data["gameStats"][v]["passingTouchdowns"]}|'
+    pass_homeRow += f'{data["gameStats"][h]["passingTouchdowns"]}|'
+
+    # Sacked
+    pass_headerRow += "Sacked (Yds)|"
+    pass_alignmentRow += ":--|"
+    pass_visitorRow += f'{data["gameStats"][v]["passingSacked"]} ({data["gameStats"][v]["passingSackedYardsLost"]})|'
+    pass_homeRow += f'{data["gameStats"][h]["passingSacked"]} ({data["gameStats"][h]["passingSackedYardsLost"]})|'
+
+    # Interceptions
+    pass_headerRow += "Int|"
+    pass_alignmentRow += ":--|"
+    pass_visitorRow += f'{data["gameStats"][v]["passingInterceptions"]}|'
+    pass_homeRow += f'{data["gameStats"][h]["passingInterceptions"]}|'
+
+    # Rushing table
+    rush_headerRow = headerRowTemplate + "Rushing|"
+    rush_alignmentRow = alignmentRowTemplate
+    rush_visitorRow = visitorRowTemplate
+    rush_homeRow = homeRowTemplate
+
+    # Rushing attempts
+    rush_headerRow += "Att|"
+    rush_alignmentRow += ":--|"
+    rush_visitorRow += f'{data["gameStats"][v]["rushingAttempts"]}|'
+    rush_homeRow += f'{data["gameStats"][h]["rushingAttempts"]}|'
+
+    # Rushing yds
+    rush_headerRow += "Yds Tot/Avg/Lng|"
+    rush_alignmentRow += ":--|"
+    rush_visitorRow += f'{data["gameStats"][v]["rushingYards"]}/{data["gameStats"][v]["rushingAverageYards"]}/{data["gameStats"][v]["rushingLong"]}|'
+    rush_homeRow += f'{data["gameStats"][h]["rushingYards"]}/{data["gameStats"][h]["rushingAverageYards"]}/{data["gameStats"][h]["rushingLong"]}|'
+
+    # Rushing 1st downs
+    rush_headerRow += "1st Dn|"
+    rush_alignmentRow += ":--|"
+    rush_visitorRow += f'{data["gameStats"][v]["rushingFirstDowns"]}|'
+    rush_homeRow += f'{data["gameStats"][h]["rushingFirstDowns"]}|'
+
+    # Rushing TD
+    rush_headerRow += "TD|"
+    rush_alignmentRow += ":--|"
+    rush_visitorRow += f'{data["gameStats"][v]["rushingTouchdowns"]}|'
+    rush_homeRow += f'{data["gameStats"][h]["rushingTouchdowns"]}|'
+
+    # Rushing Fumbles
+    rush_headerRow += "Fumbles|"
+    rush_alignmentRow += ":--|"
+    rush_visitorRow += f'{data["gameStats"][v]["rushingFumbles"]}|'
+    rush_homeRow += f'{data["gameStats"][h]["rushingFumbles"]}|'
+
+    # Kick/punt return table
+    kr_headerRow = headerRowTemplate + "Kick/Punt Ret|"
+    kr_alignmentRow = alignmentRowTemplate
+    kr_visitorRow = visitorRowTemplate
+    kr_homeRow = homeRowTemplate
+
+    # Kick returns
+    kr_headerRow += "Kick Returns|"
+    kr_alignmentRow += ":--|"
+    kr_visitorRow += f'{data["gameStats"][v]["kickReturns"]}|'
+    kr_homeRow += f'{data["gameStats"][h]["kickReturns"]}|'
+
+    # Kick return fair catches
+    kr_headerRow += "KR FC|"
+    kr_alignmentRow += ":--|"
+    kr_visitorRow += f'{data["gameStats"][v]["kickReturnsFairCatches"]}|'
+    kr_homeRow += f'{data["gameStats"][h]["kickReturnsFairCatches"]}|'
+
+    # Kick returns
+    kr_headerRow += "KR Yds Tot/Avg/Lng|"
+    kr_alignmentRow += ":--|"
+    kr_visitorRow += f'{data["gameStats"][v]["kickReturnsYards"]}/{data["gameStats"][v]["kickReturnsAverageYards"]}/{data["gameStats"][v]["kickReturnsLong"]}|'
+    kr_homeRow += f'{data["gameStats"][h]["kickReturnsYards"]}/{data["gameStats"][h]["kickReturnsAverageYards"]}/{data["gameStats"][h]["kickReturnsLong"]}|'
+
+    # Kick return TD
+    kr_headerRow += "KR TD|"
+    kr_alignmentRow += ":--|"
+    kr_visitorRow += f'{data["gameStats"][v]["kickReturnsTouchdowns"]}|'
+    kr_homeRow += f'{data["gameStats"][h]["kickReturnsTouchdowns"]}|'
+
+    # Punt return yds
+    kr_headerRow += "Punt Returns|"
+    kr_alignmentRow += ":--|"
+    kr_visitorRow += f'{data["gameStats"][v]["puntReturns"]}|'
+    kr_homeRow += f'{data["gameStats"][h]["puntReturns"]}|'
+
+    # Punt return fair catches
+    kr_headerRow += "PR FC|"
+    kr_alignmentRow += ":--|"
+    kr_visitorRow += f'{data["gameStats"][v]["puntReturnsFairCatches"]}|'
+    kr_homeRow += f'{data["gameStats"][h]["puntReturnsFairCatches"]}|'
+
+    # Punt return yds
+    kr_headerRow += "PR Yds Tot/Avg/Lng|"
+    kr_alignmentRow += ":--|"
+    kr_visitorRow += f'{data["gameStats"][v]["puntReturnsYards"]}/{data["gameStats"][v]["puntReturnsAverageYards"]}/{data["gameStats"][v]["puntReturnsLong"]}|'
+    kr_homeRow += f'{data["gameStats"][h]["puntReturnsYards"]}/{data["gameStats"][h]["puntReturnsAverageYards"]}/{data["gameStats"][h]["puntReturnsLong"]}|'
+
+    # Punt return TD
+    kr_headerRow += "PR TD|"
+    kr_alignmentRow += ":--|"
+    kr_visitorRow += f'{data["gameStats"][v]["puntReturnsTouchdowns"]}|'
+    kr_homeRow += f'{data["gameStats"][h]["puntReturnsTouchdowns"]}|'
+%>\
+${'##'} Team Stats
+
+${gen_headerRow}
+${gen_alignmentRow}
+${gen_visitorRow}
+${gen_homeRow}
+
+${pass_headerRow}
+${pass_alignmentRow}
+${pass_visitorRow}
+${pass_homeRow}
+
+${rush_headerRow}
+${rush_alignmentRow}
+${rush_visitorRow}
+${rush_homeRow}
+
+${kr_headerRow}
+${kr_alignmentRow}
+${kr_visitorRow}
+${kr_homeRow}

--- a/bots/nfl_game_threads/templates/game_thread.mako
+++ b/bots/nfl_game_threads/templates/game_thread.mako
@@ -1,0 +1,86 @@
+<%
+    from datetime import datetime
+    game = data["todayGames"][data["myGameIndex"]]
+    qtrDesc = {
+        1: "1st Quarter",
+        2: "2nd Quarter",
+        3: "3rd Quarter",
+        4: "4th Quarter",
+        5: "Overtime",
+        6: "Second Overtime",
+        7: "Third Overtime",
+        8: "Fourth Overtime",
+        9: "Fifth Overtime",
+        10: "Sixth Overtime",
+    }
+    downDesc = {
+        1: "1st",
+        2: "2nd",
+        3: "3rd",
+        4: "4th",
+    }
+%>\
+## Week
+%if data["currentWeek"]["weekType"] == "HOF":
+# Hall of Fame Game
+
+%elif data["currentWeek"]["weekType"] == "PRE":
+# Preseason Week ${data["currentWeek"]["week"]}
+
+%elif data["currentWeek"]["weekType"] == "REG":
+# Week ${data["currentWeek"]["week"]}
+
+%elif data["currentWeek"]["weekType"] == "WC":
+# Wild Card Game
+
+%elif data["currentWeek"]["weekType"] == "DIV":
+# Divisional Playoff Game
+
+%elif data["currentWeek"]["weekType"] == "CONF":
+# ${data["myTeam"]["conference"]["abbr"]} Champsionship Game
+
+%elif data["currentWeek"]["weekType"] == "PRO":
+# Pro Bowl
+
+%elif data["currentWeek"]["weekType"] == "SB":
+# SUPER BOWL
+
+%endif
+## Visiting Team
+${game["visitorTeam"]["fullName"]} \
+@ \
+## Home Team
+${game["homeTeam"]["fullName"]}
+
+## Date/Time
+Game Time: ${data["gameTime"]["myTeam"].strftime(settings.get("Tailgate Thread", {}).get("TITLE_DATE_FORMAT","%B %d, %Y @ %I:%M %p %Z"))}
+
+Venue: ${game["venue"]["name"]}
+
+%if game["gameStatus"]["phase"] in ["INGAME", "HALFTIME", "FINAL", "FINAL_OVERTIME"]:
+## Only include the line score if the game has already started
+<%include file="linescore.mako" />
+%endif
+
+%if game["gameStatus"]["phase"] == "INGAME":
+${'##'} Game Status\
+${f" - {qtrDesc[data['gameDetails']['period']]}" if data["gameDetails"].get("period") else ""}\
+${data["gameDetails"]["gameClock"]}
+
+${data["gameDetails"]["possessionTeam"]["nickName"]} \
+${downDesc[data["gameDetails"]["down"]]} and ${"Goal" if data["gameDetails"]["goalToGo"] else data["gameDetails"]["distance"]} @ \
+${game["gameStatus"]["yardLineSide"]} ${game["gameStatus"]["yardLineNumber"]}
+%elif game["gameStatus"]["phase"] == "HALFTIME":
+${'##'} Game Status: HALFTIME
+%endif
+%if game["gameStatus"]["phase"] != "PREGAME":
+
+<%include file="scoring_drives.mako" />
+
+<%include file="game_stats.mako" />
+%endif
+
+<%include file="division_scoreboard.mako" />
+
+## Configurable footer text
+${settings.get('Game Thread',{}).get('FOOTER','')}

--- a/bots/nfl_game_threads/templates/game_title.mako
+++ b/bots/nfl_game_threads/templates/game_title.mako
@@ -1,0 +1,57 @@
+<%
+    from datetime import datetime
+    prefix = settings.get("Game Thread", {}).get("TITLE_PREFIX","Game Thread:")
+    game = data["todayGames"][data["myGameIndex"]]
+    myTeamStandings = next((
+        x.get("standings", {}).get("data", {})[0]
+        for x in data["standings"] 
+        if x["abbr"] == data["myTeam"]["abbr"]
+    ), {})
+    myTeamRecord = (
+        f" ({myTeamStandings['overallWins']}-{myTeamStandings['overallLosses']}{'-'+str(myTeamStandings['overallTies']) if myTeamStandings['overallTies'] > 0 else ''})"
+        if len(myTeamStandings)
+        else " (0-0)"
+        ##if data["currentWeek"]["weekType"] != "REG"
+        ##else ""
+    )
+    oppTeamStandings = next((
+        x.get("standings", {}).get("data", {})[0]
+        for x in data["standings"] 
+        if x["abbr"] == data["oppTeam"]["abbr"]
+    ), {})
+    oppTeamRecord = (
+        f" ({oppTeamStandings['overallWins']}-{oppTeamStandings['overallLosses']}{'-'+str(oppTeamStandings['overallTies']) if oppTeamStandings['overallTies'] > 0 else ''})"
+        if len(oppTeamStandings)
+        else " (0-0)"
+        ##if data["currentWeek"]["weekType"] == "REG"
+        ##else ""
+    )
+%>\
+## Prefix
+${prefix + (" " if len(prefix) and not prefix.endswith(" ") else "")}\
+## Week
+%if data["currentWeek"]["weekType"] == "HOF":
+Hall of Fame Game - 
+%elif data["currentWeek"]["weekType"] == "PRE":
+Preseason Week ${data["currentWeek"]["week"]} - 
+%elif data["currentWeek"]["weekType"] == "REG":
+Week ${data["currentWeek"]["week"]} - 
+%elif data["currentWeek"]["weekType"] == "WC":
+Wild Card Game - 
+%elif data["currentWeek"]["weekType"] == "DIV":
+Divisional Playoff Game - 
+%elif data["currentWeek"]["weekType"] == "CONF":
+${data["myTeam"]["conference"]["abbr"]} Champsionship Game - 
+%elif data["currentWeek"]["weekType"] == "PRO":
+Pro Bowl - 
+%elif data["currentWeek"]["weekType"] == "SB":
+SUPER BOWL - 
+%endif
+## Visiting Team
+${game["visitorTeam"]["fullName"]}${myTeamRecord if data["homeVisitor"] == "visitor" else oppTeamRecord} \
+@ \
+## Home Team
+${game["homeTeam"]["fullName"]}${myTeamRecord if data["homeVisitor"] == "home" else oppTeamRecord} \
+- \
+## Date/Time
+${data["gameTime"]["myTeam"].strftime(settings.get("Game Thread", {}).get("TITLE_DATE_FORMAT","%B %d, %Y @ %I:%M %p %Z"))}

--- a/bots/nfl_game_threads/templates/inactives.mako
+++ b/bots/nfl_game_threads/templates/inactives.mako
@@ -1,0 +1,37 @@
+<%
+    rosterStatusKey = {
+        "ACT": "Active",
+        "DEV": "Development Squad",
+        "CUT": "Cut",
+        "RES": "Reserved",
+        "SUS": "Suspended",
+        "RSN": "?",
+        "TRD": "Traded to another division",
+        "TRT": "Traded from Team",
+        "TRC": "Traded to another Conference",
+        "EXE": "Exempt",
+        "NWT": "Not with team",
+        "PUP": "Physically Unable to Perform",
+        "UDF": "Unsigned Draft Pick",
+        "RFA": "Restricted Free Agent",
+        "UFA": "Unrestricted Free Agent",
+        "NON": "Non football related injured reserve",
+        "RET": "Retired",
+    }
+    excludeRosterStatus = ["ACT", "DEV", "CUT", "TRD", "TRT", "TRC", "UDF", "RFA", "UFA", "RET"]
+    myInactives = [x for x in data["myTeam"]["roster"]["data"] if x["activeRole"] == "PLAYER" and x["player"]["rosterStatus"] not in excludeRosterStatus]
+    oppInactives = [x for x in data["oppTeam"]["roster"]["data"] if x["activeRole"] == "PLAYER" and x["player"]["rosterStatus"] not in excludeRosterStatus]
+%>\
+% if len(myInactives):
+${'##'} ${data["myTeam"]["nickName"]} Inactives & Injury Status
+% for x in set(x["player"]["rosterStatus"] for x in myInactives):
+* ${f"{rosterStatusKey[x]}: {', '.join([p['player']['position']['abbr'] + ' ' + p['displayName'] for p in myInactives if p['player']['rosterStatus'] == x])}"}
+% endfor
+% endif
+
+% if len(myInactives):
+${'##'} ${data["oppTeam"]["nickName"]} Inactives & Injury Status
+% for x in set(x["player"]["rosterStatus"] for x in myInactives):
+* ${f"{rosterStatusKey[x]}: {', '.join([p['player']['position']['abbr'] + ' ' + p['displayName'] for p in myInactives if p['player']['rosterStatus'] == x])}"}
+% endfor
+% endif

--- a/bots/nfl_game_threads/templates/linescore.mako
+++ b/bots/nfl_game_threads/templates/linescore.mako
@@ -1,0 +1,41 @@
+<%
+    game = data["todayGames"][data["myGameIndex"]]
+    visitorTeam = (
+        data["myTeam"] if data["homeVisitor"] == "visitor"
+        else data["oppTeam"]
+    )
+    homeTeam = (
+        data["myTeam"] if data["homeVisitor"] == "home"
+        else data["oppTeam"]
+    )
+    if (
+        game.get("homeTeamScore", {}).get("pointsTotal") is not None
+        and game.get("visitorTeamScore", {}).get("pointsTotal") is not None
+    ):
+        vs = game["visitorTeamScore"]
+        hs = game["homeTeamScore"]
+        headerLine = "||1|2|3|4|"
+        alignmentLine = "|:--|:--|:--|:--|:--|"
+        visitorLine = f'|{visitorTeam["nickName"]}|{vs.get("pointsQ1", 0)}|{vs.get("pointsQ2", 0)}|{vs.get("pointsQ3", 0)}|{vs.get("pointsQ4", 0)}|'
+        homeLine = f'|{homeTeam["nickName"]}|{hs.get("pointsQ1", 0)}|{hs.get("pointsQ2", 0)}|{hs.get("pointsQ3", 0)}|{hs.get("pointsQ4", 0)}|'
+        if game["gameStatus"]["phase"] == "FINAL_OVERTIME" or vs.get("pointsOvertime", {}).get("pointsOvertimeTotal", 0) > 0 or hs.get("pointsOvertime", {}).get("pointsOvertimeTotal", 0) > 0:
+            for i, x in [(i, x) for i, x in enumerate(vs.get("pointsOvertime", {}).get("data", []))]:
+                if len(vs.get("pointsOvertime", {}).get("data", [])) > 1:
+                    headerLine += f"OT{i+1}|"
+                    alignmentLine += ":--|"
+                    visitorLine += f"{x}|"
+                    homeLine += f'{hs.get("pointsOvertime", {}).get("data", [])[i]}|'
+                else:
+                    headerLine += f"OT|"
+                    alignmentLine += ":--|"
+                    visitorLine += f"{x}|"
+                    homeLine += f'{hs.get("pointsOvertime", {}).get("data", [])[i]}|'
+        headerLine += "TOTAL|"
+        alignmentLine += ":--|"
+        visitorLine += f"{vs['pointsTotal']}|"
+        homeLine += f"{hs['pointsTotal']}|"
+%>\
+${headerLine}
+${alignmentLine}
+${visitorLine}
+${homeLine}

--- a/bots/nfl_game_threads/templates/post_thread.mako
+++ b/bots/nfl_game_threads/templates/post_thread.mako
@@ -1,0 +1,101 @@
+<%
+    from datetime import datetime
+    game = data["todayGames"][data["myGameIndex"]]
+    oppHomeVisitor = "visitor" if data["homeVisitor"] == "home" else "home"
+    result = (
+        "tie" if game[data["homeVisitor"] + "TeamScore"]["pointsTotal"] == game[oppHomeVisitor + "TeamScore"]["pointsTotal"]
+        else "win" if game[data["homeVisitor"] + "TeamScore"]["pointsTotal"] > game[oppHomeVisitor + "TeamScore"]["pointsTotal"]
+        else "loss" if game[data["homeVisitor"] + "TeamScore"]["pointsTotal"] < game[oppHomeVisitor + "TeamScore"]["pointsTotal"]
+        else ""
+    )
+    myTeamStandings = next((
+        x.get("standings", {}).get("data", {})[0]
+        for x in data["standings"] 
+        if x["abbr"] == data["myTeam"]["abbr"]
+    ), {})
+    myTeamRecord = (
+        f" ({myTeamStandings['overallWins']}-{myTeamStandings['overallLosses']}{'-'+str(myTeamStandings['overallTies']) if myTeamStandings['overallTies'] > 0 else ''})"
+        ##if data["currentWeek"]["weekType"] == "REG"
+        ##else ""
+    )
+    oppTeamStandings = next((
+        x.get("standings", {}).get("data", {})[0]
+        for x in data["standings"] 
+        if x["abbr"] == data["oppTeam"]["abbr"]
+    ), {})
+    oppTeamRecord = (
+        f" ({oppTeamStandings['overallWins']}-{oppTeamStandings['overallLosses']}{'-'+str(oppTeamStandings['overallTies']) if oppTeamStandings['overallTies'] > 0 else ''})"
+        ##if data["currentWeek"]["weekType"] == "REG"
+        ##else ""
+    )
+%>\
+## Week
+%if data["currentWeek"]["weekType"] == "HOF":
+# Hall of Fame Game
+
+%elif data["currentWeek"]["weekType"] == "PRE":
+# Preseason Week ${data["currentWeek"]["week"]}
+
+%elif data["currentWeek"]["weekType"] == "REG":
+# Week ${data["currentWeek"]["week"]}
+
+%elif data["currentWeek"]["weekType"] == "WC":
+# Wild Card Game
+
+%elif data["currentWeek"]["weekType"] == "DIV":
+# Divisional Playoff Game
+
+%elif data["currentWeek"]["weekType"] == "CONF":
+# ${data["myTeam"]["conference"]["abbr"]} Champsionship Game
+
+%elif data["currentWeek"]["weekType"] == "PRO":
+# Pro Bowl
+
+%elif data["currentWeek"]["weekType"] == "SB":
+%if result == "win":
+## Boom
+# THE ${data["myTeam"]["fullName"].upper()} HAVE WON THE SUPER BOWL!
+%else:
+# Super Bowl
+%endif
+
+%endif
+## Make the matchup h2
+${'##'} \
+## Visiting Team
+${game["visitorTeam"]["fullName"]}${myTeamRecord if data["homeVisitor"] == "visitor" else oppTeamRecord} \
+@ \
+## Home Team
+${game["homeTeam"]["fullName"]}${myTeamRecord if data["homeVisitor"] == "home" else oppTeamRecord}
+
+%if result != "":
+${'##'} Final Score: \
+${max(int(game[data["homeVisitor"] + "TeamScore"]["pointsTotal"]), int(game[oppHomeVisitor + "TeamScore"]["pointsTotal"]))}\
+-\
+${min(int(game[data["homeVisitor"] + "TeamScore"]["pointsTotal"]), int(game[oppHomeVisitor + "TeamScore"]["pointsTotal"]))} \
+%if result == "tie":
+TIE
+%elif result == "win":
+${data["myTeam"]["nickName"]}
+%elif result == "loss":
+${data["oppTeam"]["nickName"]}
+%endif
+%endif
+
+## Date/Time
+Game Time: ${data["gameTime"]["myTeam"].strftime(settings.get("Tailgate Thread", {}).get("TITLE_DATE_FORMAT","%B %d, %Y @ %I:%M %p %Z"))}
+
+Venue: ${game["venue"]["name"]}
+
+<%include file="linescore.mako" />
+
+<%include file="scoring_drives.mako" />
+
+<%include file="game_stats.mako" />
+
+<%include file="standings.mako" />
+
+<%include file="division_scoreboard.mako" />
+
+## Configurable footer text
+${settings.get('Post Game Thread',{}).get('FOOTER','')}

--- a/bots/nfl_game_threads/templates/post_title.mako
+++ b/bots/nfl_game_threads/templates/post_title.mako
@@ -1,0 +1,66 @@
+<%
+    from datetime import datetime
+    prefix = settings.get("Post Game Thread", {}).get("TITLE_PREFIX","Post Game Thread:")
+    game = data["todayGames"][data["myGameIndex"]]
+    oppHomeVisitor = "visitor" if data["homeVisitor"] == "home" else "home"
+    result = (
+        "tie" if game[data["homeVisitor"] + "TeamScore"]["pointsTotal"] == game[oppHomeVisitor + "TeamScore"]["pointsTotal"]
+        else "win" if game[data["homeVisitor"] + "TeamScore"]["pointsTotal"] > game[oppHomeVisitor + "TeamScore"]["pointsTotal"]
+        else "loss" if game[data["homeVisitor"] + "TeamScore"]["pointsTotal"] < game[oppHomeVisitor + "TeamScore"]["pointsTotal"]
+        else ""
+    )
+%>\
+## Prefix
+${prefix + (" " if len(prefix) and not prefix.endswith(" ") else "")}\
+## Week
+%if data["currentWeek"]["weekType"] == "HOF":
+Hall of Fame Game - \
+%elif data["currentWeek"]["weekType"] == "PRE":
+Preseason Week ${data["currentWeek"]["week"]} - \
+%elif data["currentWeek"]["weekType"] == "REG":
+Week ${data["currentWeek"]["week"]} - \
+%elif data["currentWeek"]["weekType"] == "WC":
+Wild Card Game - \
+%elif data["currentWeek"]["weekType"] == "DIV":
+Divisional Playoff Game - \
+%elif data["currentWeek"]["weekType"] == "CONF":
+${data["myTeam"]["conference"]["abbr"]} Champsionship Game - \
+%elif data["currentWeek"]["weekType"] == "PRO":
+Pro Bowl - \
+%elif data["currentWeek"]["weekType"] == "SB":
+SUPER BOWL${" CHAMPIONS!" if result=="win" else " -"} \
+%endif
+## My Team
+The ${data["myTeam"]["nickName"]} \
+## Result
+%if result == "tie":
+## TIE
+tied the \
+%elif result == "win":
+## WIN
+defeated the \
+%elif result == "loss":
+## LOSS
+fell to the \
+%else:
+## EXCEPTION
+were supposed to play the \
+%endif
+## Opposing Team
+${data["oppTeam"]["nickName"]} \
+## Score
+%if result == "tie":
+## TIE
+with ${game["homeTeamScore"]["pointsTotal"]} points each \
+%elif result == "win":
+## WIN
+by a score of ${game[data["homeVisitor"] + "TeamScore"]["pointsTotal"]} to ${game[oppHomeVisitor + "TeamScore"]["pointsTotal"]} \
+%elif result == "loss":
+## LOSS
+by a score of ${game[oppHomeVisitor + "TeamScore"]["pointsTotal"]} to ${game[data["homeVisitor"] + "TeamScore"]["pointsTotal"]} \
+%else:
+## EXCEPTION
+%endif
+- \
+## Date/Time
+${data["gameTime"]["myTeam"].strftime(settings.get("Post Game Thread", {}).get("TITLE_DATE_FORMAT","%B %d, %Y @ %I:%M %p %Z"))}

--- a/bots/nfl_game_threads/templates/scoring_drives.mako
+++ b/bots/nfl_game_threads/templates/scoring_drives.mako
@@ -1,0 +1,22 @@
+<%
+    game = data["todayGames"][data["myGameIndex"]]
+%>\
+%if len(data["gameDetails"]["scoringSummaries"]) > 0:
+${'##'} Scoring Drives
+%for x in data["gameDetails"]["scoringSummaries"]:
+<%
+play = next((p for p in data["gameDetails"]["plays"] if p["playId"] == x["playId"]), None)
+%>\
+%if play:
+* Q${play["quarter"]} ${play["scoringTeam"]["abbreviation"]} ${play["shortDescription"]} - Score: ${max(x["visitorScore"], x["homeScore"])}-${min(x["visitorScore"], x["homeScore"])} \
+%if x["visitorScore"] > x["homeScore"]:
+${game["visitorTeam"]["abbr"]}
+%elif x["homeScore"] > x["visitorScore"]:
+${game["homeTeam"]["abbr"]}
+%else:
+## don't list a team abbr if game is tied
+
+%endif
+%endif
+%endfor
+%endif

--- a/bots/nfl_game_threads/templates/standings.mako
+++ b/bots/nfl_game_threads/templates/standings.mako
@@ -1,0 +1,10 @@
+<%
+    if not len(data["standings"]):
+        return
+    unsortedDivStandings = {x["standings"]["data"][0]["divisionRank"]: x for x in data["standings"] if x["division"]["abbr"] == data["myTeam"]["division"]["abbr"]}
+    sortedDivStandings = [unsortedDivStandings[x] for x in sorted(unsortedDivStandings)]    
+%>\
+${'##'} Standings
+|${sortedDivStandings[0]["division"]["abbr"]} Rank|Team|Wins|Losses|Ties|Win%|
+|:--|:--|:--|:--|:--|:--|
+${"\n".join([f"|{x['standings']['data'][0]['divisionRank']}|{x['abbr']}|{x['standings']['data'][0]['overallWins']}|{x['standings']['data'][0]['overallLosses']}|{x['standings']['data'][0]['overallTies']}|{x['standings']['data'][0]['overallWinPct']}|" for x in sortedDivStandings])}

--- a/bots/nfl_game_threads/templates/tailgate_thread.mako
+++ b/bots/nfl_game_threads/templates/tailgate_thread.mako
@@ -1,0 +1,73 @@
+<%
+    from datetime import datetime
+    game = data["todayGames"][data["myGameIndex"]]
+    myTeamStandings = next((
+        x.get("standings", {}).get("data", {})[0]
+        for x in data["standings"] 
+        if x["abbr"] == data["myTeam"]["abbr"]
+    ), {})
+    myTeamRecord = (
+        f" ({myTeamStandings['overallWins']}-{myTeamStandings['overallLosses']}{'-'+str(myTeamStandings['overallTies']) if myTeamStandings['overallTies'] > 0 else ''})"
+        if len(myTeamStandings)
+        else ""
+        ##if data["currentWeek"]["weekType"] == "REG"
+        ##else ""
+    )
+    oppTeamStandings = next((
+        x.get("standings", {}).get("data", {})[0]
+        for x in data["standings"] 
+        if x["abbr"] == data["oppTeam"]["abbr"]
+    ), {})
+    oppTeamRecord = (
+        f" ({oppTeamStandings['overallWins']}-{oppTeamStandings['overallLosses']}{'-'+str(oppTeamStandings['overallTies']) if oppTeamStandings['overallTies'] > 0 else ''})"
+        if len(oppTeamStandings)
+        else ""
+        ##if data["currentWeek"]["weekType"] == "REG"
+        ##else ""
+    )
+%>\
+## Week
+%if data["currentWeek"]["weekType"] == "HOF":
+# Hall of Fame Game
+
+%elif data["currentWeek"]["weekType"] == "PRE":
+# Preseason Week ${data["currentWeek"]["week"]}
+
+%elif data["currentWeek"]["weekType"] == "REG":
+# Week ${data["currentWeek"]["week"]}
+
+%elif data["currentWeek"]["weekType"] == "WC":
+# Wild Card Game
+
+%elif data["currentWeek"]["weekType"] == "DIV":
+# Divisional Playoff Game
+
+%elif data["currentWeek"]["weekType"] == "CONF":
+# ${data["myTeam"]["conference"]["abbr"]} Champsionship Game
+
+%elif data["currentWeek"]["weekType"] == "PRO":
+# Pro Bowl
+
+%elif data["currentWeek"]["weekType"] == "SB":
+# SUPER BOWL
+
+%endif
+## Visiting Team
+${game["visitorTeam"]["fullName"]}${myTeamRecord if data["homeVisitor"] == "visitor" else oppTeamRecord} \
+@ \
+## Home Team
+${game["homeTeam"]["fullName"]}${myTeamRecord if data["homeVisitor"] == "home" else oppTeamRecord}
+
+## Date/Time
+Game Time: ${data["gameTime"]["myTeam"].strftime(settings.get("Tailgate Thread", {}).get("TITLE_DATE_FORMAT","%B %d, %Y @ %I:%M %p %Z"))}
+
+Venue: ${game["venue"]["name"]}
+
+<%include file="standings.mako" />
+
+<%include file="inactives.mako" />
+
+<%include file="division_scoreboard.mako" />
+
+## Configurable footer text
+${settings.get('Tailgate Thread',{}).get('FOOTER','')}

--- a/bots/nfl_game_threads/templates/tailgate_title.mako
+++ b/bots/nfl_game_threads/templates/tailgate_title.mako
@@ -1,0 +1,57 @@
+<%
+    from datetime import datetime
+    prefix = settings.get("Tailgate Thread", {}).get("TITLE_PREFIX","Tailgate Thread:")
+    game = data["todayGames"][data["myGameIndex"]]
+    myTeamStandings = next((
+        x.get("standings", {}).get("data", {})[0]
+        for x in data["standings"] 
+        if x["abbr"] == data["myTeam"]["abbr"]
+    ), {})
+    myTeamRecord = (
+        f" ({myTeamStandings['overallWins']}-{myTeamStandings['overallLosses']}{'-'+str(myTeamStandings['overallTies']) if myTeamStandings['overallTies'] > 0 else ''})"
+        if len(myTeamStandings)
+        else " (0-0)"
+        ##if data["currentWeek"]["weekType"] != "REG"
+        ##else ""
+    )
+    oppTeamStandings = next((
+        x.get("standings", {}).get("data", {})[0]
+        for x in data["standings"] 
+        if x["abbr"] == data["oppTeam"]["abbr"]
+    ), {})
+    oppTeamRecord = (
+        f" ({oppTeamStandings['overallWins']}-{oppTeamStandings['overallLosses']}{'-'+str(oppTeamStandings['overallTies']) if oppTeamStandings['overallTies'] > 0 else ''})"
+        if len(oppTeamStandings)
+        else " (0-0)"
+        ##if data["currentWeek"]["weekType"] == "REG"
+        ##else ""
+    )
+%>\
+## Prefix
+${prefix + (" " if len(prefix) and not prefix.endswith(" ") else "")}\
+## Week
+%if data["currentWeek"]["weekType"] == "HOF":
+Hall of Fame Game - 
+%elif data["currentWeek"]["weekType"] == "PRE":
+Preseason Week ${data["currentWeek"]["week"]} - 
+%elif data["currentWeek"]["weekType"] == "REG":
+Week ${data["currentWeek"]["week"]} - 
+%elif data["currentWeek"]["weekType"] == "WC":
+Wild Card Game - 
+%elif data["currentWeek"]["weekType"] == "DIV":
+Divisional Playoff Game - 
+%elif data["currentWeek"]["weekType"] == "CONF":
+${data["myTeam"]["conference"]["abbr"]} Champsionship Game - 
+%elif data["currentWeek"]["weekType"] == "PRO":
+Pro Bowl - 
+%elif data["currentWeek"]["weekType"] == "SB":
+SUPER BOWL - 
+%endif
+## Visiting Team
+${game["visitorTeam"]["fullName"]}${myTeamRecord if data["homeVisitor"] == "visitor" else oppTeamRecord} \
+@ \
+## Home Team
+${game["homeTeam"]["fullName"]}${myTeamRecord if data["homeVisitor"] == "home" else oppTeamRecord} \
+- \
+## Date/Time
+${data["gameTime"]["myTeam"].strftime(settings.get("Tailgate Thread", {}).get("TITLE_DATE_FORMAT","%B %d, %Y @ %I:%M %p %Z"))}

--- a/bots/nfl_game_threads_config.json
+++ b/bots/nfl_game_threads_config.json
@@ -1,0 +1,797 @@
+{
+    "Tailgate Thread": [
+        {
+            "key": "ENABLED",
+            "description": "Enable posting of tailgate threads.",
+            "type": "bool",
+            "val": true,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "FLAIR",
+            "description": "Flair to add to tailgate thread post.",
+            "type": "str",
+            "val": "Tailgate Thread",
+            "options": [],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "LIVE_DISCUSSION",
+            "description": "Submit posts as `live discussions` instead of traditional comment threads on new Reddit (old Reddit will still show traditional comment threads).",
+            "type": "bool",
+            "val": false,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "FOOTER",
+            "description": "Footer text to include at the bottom of the thread.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "POST_TIME",
+            "description": "Time of day when tailgate thread should be posted. Include zero-padded hour and minute in 24 hour time, e.g. 08:00 or 14:30.",
+            "type": "str",
+            "val": "05:00",
+            "options": [],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "SUGGESTED_SORT",
+            "description": "Suggested sort to set on the tailgate thread post.",
+            "type": "str",
+            "val": "new",
+            "options": [
+                "",
+                "confidence",
+                "top",
+                "new",
+                "controversial",
+                "old",
+                "random",
+                "qa"
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "SUPPRESS_MINUTES",
+            "description": "Tailgate thread will be skipped if game thread will be posted within this many minutes. Set to 0 to suppress tailgate thread only if it is already time to post game thread. Set to -1 to never suppress tailgate thread.",
+            "type": "int",
+            "val": 60,
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "THREAD_TEMPLATE",
+            "description": "Template for the thread body. Don't modify the standard template file because your changes will be lost when updating. Make a copy instead and put the filename here. Path: /redball/bots/game_threads/templates/",
+            "type": "str",
+            "val": "tailgate_thread.mako",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "TITLE_PREFIX",
+            "description": "Prefix to include at the beginning of the thread title, after the team name. Trailing space and separator dash will be added.",
+            "type": "str",
+            "val": "Tailgate Thread:",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "TITLE_TEMPLATE",
+            "description": "Template for the post title. Don't modify the standard template file because your changes will be lost when updating. Make a copy instead and put the filename here. Path: /redball/bots/game_threads/templates/",
+            "type": "str",
+            "val": "tailgate_title.mako",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "UPDATE_INTERVAL",
+            "description": "Number of minutes between tailgate thread updates.",
+            "type": "int",
+            "val": 5,
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "UPDATE_UNTIL",
+            "description": "Keep updating the thread until the selected threshold is reached.",
+            "type": "str",
+            "val": "Game thread is posted",
+            "options": [
+                "Do not update",
+                "Game thread is posted",
+                "All division games are final",
+                "All NFL games are final"
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "WEBHOOK_URL",
+            "description": "URL to call when thread is posted.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "WEBHOOK_TEMPLATE",
+            "description": "Template to parse for body of call to WEBHOOK_URL.",
+            "type": "str",
+            "val": "tailgate_webhook.mako",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        }
+    ],
+    "Game Thread": [
+        {
+            "key": "ENABLED",
+            "description": "Enable posting of game threads.",
+            "type": "bool",
+            "val": true,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "FLAIR",
+            "description": "Flair to add to game thread post.",
+            "type": "str",
+            "val": "Game Thread",
+            "options": [],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "LIVE_DISCUSSION",
+            "description": "Submit posts as `live discussions` instead of traditional comment threads on new Reddit (old Reddit will still show traditional comment threads).",
+            "type": "bool",
+            "val": false,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "LOCK_TAILGATE_THREAD",
+            "description": "Lock the tailgate thread when game thread is posted.",
+            "type": "bool",
+            "val": false,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "FOOTER",
+            "description": "Footer text to include at the bottom of the thread.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "MINUTES_BEFORE",
+            "description": "How many minutes before the scheduled game start time to post the game thread.",
+            "type": "int",
+            "val": 60,
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "POST_BY",
+            "description": "Time of day by which game thread should be posted, if the configured time comes before MINUTES_BEFORE setting. Include zero-padded hour and minute in 24 hour time, e.g. 08:00 or 14:30.",
+            "type": "str",
+            "val": "19:30",
+            "options": [],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "SUGGESTED_SORT",
+            "description": "Suggested sort to set on the game thread post.",
+            "type": "str",
+            "val": "new",
+            "options": [
+                "",
+                "confidence",
+                "top",
+                "new",
+                "controversial",
+                "old",
+                "random",
+                "qa"
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "THREAD_TEMPLATE",
+            "description": "Template for the thread body. Don't modify the standard template file because your changes will be lost when updating. Make a copy instead and put the filename here. Path: /redball/bots/game_threads/templates/",
+            "type": "str",
+            "val": "game_thread.mako",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "TITLE_PREFIX",
+            "description": "Prefix to include at the beginning of the thread title (include : or - if desired). Trailing space will be added if not blank.",
+            "type": "str",
+            "val": "Game Thread:",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "TITLE_TEMPLATE",
+            "description": "Template for the post title. Don't modify the standard template file because your changes will be lost when updating. Make a copy instead and put the filename here. Path: /redball/bots/game_threads/templates/",
+            "type": "str",
+            "val": "game_title.mako",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "UPDATE_INTERVAL",
+            "description": "Number of seconds between game thread updates.",
+            "type": "int",
+            "val": 10,
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "UPDATE_INTERVAL_NOT_LIVE",
+            "description": "Number of minutes between game thread updates while the game is not live (including pregame and halftime).",
+            "type": "int",
+            "val": 1,
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "UPDATE_UNTIL",
+            "description": "Keep updating the thread until the selected threshold is reached.",
+            "type": "str",
+            "val": "My team's game is final",
+            "options": [
+                "Do not update",
+                "My team's game is final",
+                "All division games are final",
+                "All NFL games are final"
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "WEBHOOK_URL",
+            "description": "URL to call when thread is posted.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "WEBHOOK_TEMPLATE",
+            "description": "Template to parse for body of call to WEBHOOK_URL.",
+            "type": "str",
+            "val": "game_webhook.mako",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        }
+    ],
+    "Logging": [
+        {
+            "key": "CONSOLE_LOG_LEVEL",
+            "description": "Console Log Level",
+            "type": "str",
+            "val": "INFO",
+            "options": [
+                "DEBUG",
+                "INFO",
+                "WARNING",
+                "ERROR"
+            ],
+            "subkeys": [],
+            "parent_key": "LOG_TO_CONSOLE"
+        },
+        {
+            "key": "FILE_LOG_LEVEL",
+            "description": "File Log Level",
+            "type": "str",
+            "val": "DEBUG",
+            "options": [
+                "DEBUG",
+                "INFO",
+                "WARNING",
+                "ERROR"
+            ],
+            "subkeys": [],
+            "parent_key": "LOG_TO_FILE"
+        },
+        {
+            "key": "LOG_TO_CONSOLE",
+            "description": "Log to Console",
+            "type": "bool",
+            "val": true,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [
+                "CONSOLE_LOG_LEVEL"
+            ],
+            "parent_key": ""
+        },
+        {
+            "key": "LOG_TO_FILE",
+            "description": "Log to File",
+            "type": "bool",
+            "val": true,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [
+                "FILE_LOG_LEVEL",
+                "LOG_RETENTION"
+            ],
+            "parent_key": ""
+        },
+        {
+            "key": "LOG_RETENTION",
+            "description": "Log File Retention (Days)",
+            "type": "int",
+            "val": 7,
+            "options": [],
+            "subkeys": [],
+            "parent_key": "LOG_TO_FILE"
+        },
+        {
+            "key": "PROPAGATE",
+            "description": "Propagate Logs",
+            "type": "bool",
+            "val": false,
+            "options": [true, false],
+            "subkeys": [],
+            "parent_key": ""
+        }
+    ],
+    "NFL": [
+        {
+            "key": "API_CACHE_SECONDS",
+            "description": "Number of seconds to cache data from NFL API",
+            "type": "int",
+            "val": 5,
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "TEAM",
+            "description": "My Team",
+            "type": "str",
+            "val": "",
+            "options": [
+                "",
+                "Arizona Cardinals|ARI",
+                "Atlanta Falcons|ATL",
+                "Baltimore Ravens|BAL",
+                "Buffalo Bills|BUF",
+                "Carolina Panthers|CAR",
+                "Chicago Bears|CHI",
+                "Cincinnati Bengals|CIN",
+                "Cleveland Browns|CLE",
+                "Dallas Cowboys|DAL",
+                "Denver Broncos|DEN",
+                "Detroit Lions|DET",
+                "Green Bay Packers|GB",
+                "Houston Texans|HOU",
+                "Indianapolis Colts|IND",
+                "Jacksonville Jaguars|JAX",
+                "Kansas City Chiefs|KC",
+                "Los Angeles Rams|LA",
+                "Los Angeles Chargers|LAC",
+                "Las Vegas Raiders|LV",
+                "Miami Dolphins|MIA",
+                "Minnesota Vikings|MIN",
+                "New England Patriots|NE",
+                "New Orleans Saints|NO",
+                "New York Giants|NYG",
+                "New York Jets|NYJ",
+                "Philadelphia Eagles|PHI",
+                "Pittsburgh Steelers|PIT",
+                "Seattle Seahawks|SEA",
+                "San Francisco 49ers|SF",
+                "Tampa Bay Buccaneers|TB",
+                "Tennessee Titans|TEN",
+                "Washington Redskins|WAS",
+                "AFC Pro Bowl Team|AFC",
+                "NFC Pro Bowl Team|NFC"
+            ],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "GAME_DATE_OVERRIDE",
+            "description": "Leave blank in most cases. Use this to force the bot to treat a specific date as 'today', and then go back to current day. Date format: %Y-%m-%d, e.g. 2019-10-25.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "SEASON_OVERRIDE",
+            "description": "Leave blank in most cases. Use this in conjunction with GAME_DATE_OVERRIDE to force the bot to treat a specific date as 'today', and then go back to current day. Format: 4-digit year e.g. 2020",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "SEASONTYPE_OVERRIDE",
+            "description": "Leave blank in most cases. Use this in conjunction with GAME_DATE_OVERRIDE to force the bot to treat a specific date as 'today', and then go back to current day.",
+            "type": "str",
+            "val": "",
+            "options": ["", "HOF", "PRE", "REG", "POST", "PRO", "SB"],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "WEEK_OVERRIDE",
+            "description": "Leave blank in most cases. Use this in conjunction with GAME_DATE_OVERRIDE to force the bot to treat a specific date as 'today', and then go back to current day. Format: number from 1-17 (resets with each seasonType)",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        }
+    ],
+    "Post Game Thread": [
+        {
+            "key": "ENABLED",
+            "description": "Enable posting of post game threads.",
+            "type": "bool",
+            "val": true,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "FLAIR",
+            "description": "Flair to add to post game thread post.",
+            "type": "str",
+            "val": "Post Game Thread",
+            "options": [],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "LIVE_DISCUSSION",
+            "description": "Submit posts as `live discussions` instead of traditional comment threads on new Reddit (old Reddit will still show traditional comment threads).",
+            "type": "bool",
+            "val": false,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "LOCK_GAME_THREAD",
+            "description": "Lock the game thread when post game thread is posted.",
+            "type": "bool",
+            "val": false,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "FOOTER",
+            "description": "Footer text to include at the bottom of the thread.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "SUGGESTED_SORT",
+            "description": "Suggested sort to set on the post game thread post.",
+            "type": "str",
+            "val": "new",
+            "options": [
+                "",
+                "confidence",
+                "top",
+                "new",
+                "controversial",
+                "old",
+                "random",
+                "qa"
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "THREAD_TEMPLATE",
+            "description": "Template for the thread body. Don't modify the standard template file because your changes will be lost when updating. Make a copy instead and put the filename here. Path: /redball/bots/game_threads/templates/",
+            "type": "str",
+            "val": "post_thread.mako",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "TITLE_PREFIX",
+            "description": "Prefix to include at the beginning of the thread title (include : or - if desired). Trailing space will be added if not blank.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "TITLE_TEMPLATE",
+            "description": "Template for the post title. Don't modify the standard template file because your changes will be lost when updating. Make a copy instead and put the filename here. Path: /redball/bots/game_threads/templates/",
+            "type": "str",
+            "val": "post_title.mako",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "UPDATE_INTERVAL",
+            "description": "Number of minutes between post game thread updates.",
+            "type": "int",
+            "val": 5,
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "UPDATE_UNTIL",
+            "description": "Keep updating the thread until the selected threshold is reached.",
+            "type": "str",
+            "val": "An hour after thread is posted",
+            "options": [
+                "Do not update",
+                "An hour after thread is posted",
+                "All division games are final",
+                "All NFL games are final"
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "WEBHOOK_URL",
+            "description": "URL to call when thread is posted.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "WEBHOOK_TEMPLATE",
+            "description": "Template to parse for body of call to WEBHOOK_URL.",
+            "type": "str",
+            "val": "post_webhook.mako",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        }
+    ],
+    "Reddit": [
+        {
+            "key": "FLAIR_MODE",
+            "description": "Method of adding flair to posts. Depends on subreddit configuration.",
+            "type": "str",
+            "val": "mod",
+            "options": [
+                "mod",
+                "submitter",
+                ""
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "INBOX_REPLIES",
+            "description": "Subscribe to inbox replies for submitted posts and comments.",
+            "type": "bool",
+            "val": false,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "STICKY",
+            "description": "Sticky submitted posts (requires mod rights in the subreddit).",
+            "type": "bool",
+            "val": true,
+            "options": [
+                true,
+                false
+            ],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "SUBREDDIT",
+            "description": "Subreddit where posts should be submitted.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": null
+        }
+    ],
+    "Bot": [
+        {
+            "key": "TEMPLATE_PATH",
+            "description": "Path where custom templates are stored (defaults to the same path as the standard templates).",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": null
+        },
+        {
+            "key": "TEAM_TIMEZONE",
+            "description": "Timezone to use for dates in the threads (e.g. game time)",
+            "type": "str",
+            "val": "America/New_York",
+            "options": [],
+            "subkeys": [],
+            "parent_key": null
+        }
+    ],
+    "Prowl" : [
+        {
+            "key": "ERROR_API_KEY",
+            "description": "API Key for sending error notifications to Prowl.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": ["ERROR_PRIORITY"],
+            "parent_key": ""
+        },
+        {
+            "key": "ERROR_PRIORITY",
+            "description": "Priority when sending error notifications to Prowl (leave blank to disable).",
+            "type": "str",
+            "val": "",
+            "options": [
+                "",
+                "-2",
+                "-1",
+                "0",
+                "1",
+                "2"
+            ],
+            "subkeys": [],
+            "parent_key": "ERROR_API_KEY"
+        },
+        {
+            "key": "THREAD_POSTED_API_KEY",
+            "description": "API Key for sending thread posted notifications to Prowl.",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": ["THREAD_POSTED_PRIORITY"],
+            "parent_key": ""
+        },
+        {
+            "key": "THREAD_POSTED_PRIORITY",
+            "description": "Priority when sending thread posted notifications to Prowl (leave blank to disable).",
+            "type": "str",
+            "val": "",
+            "options": [
+                "",
+                "-2",
+                "-1",
+                "0",
+                "1",
+                "2"
+            ],
+            "subkeys": [],
+            "parent_key": "THREAD_POSTED_API_KEY"
+        }
+    ],
+    "Twitter" : [
+        {
+            "key": "TWEET_THREAD_POSTED",
+            "description": "Tweet when threads are posted (see wiki for info).",
+            "type": "bool",
+            "val": "false",
+            "options": [true, false],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "CONSUMER_KEY",
+            "description": "Twitter Consumer Key (see wiki)",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "CONSUMER_SECRET",
+            "description": "Twitter Consumer Secret (see wiki)",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "ACCESS_TOKEN",
+            "description": "Twitter Access Token (see wiki)",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        },
+        {
+            "key": "ACCESS_SECRET",
+            "description": "Twitter Access Secret (see wiki)",
+            "type": "str",
+            "val": "",
+            "options": [],
+            "subkeys": [],
+            "parent_key": ""
+        }
+    ]
+}

--- a/redball/config.py
+++ b/redball/config.py
@@ -266,8 +266,14 @@ def add_bot_config(
         q = "INSERT OR IGNORE INTO rb_botConfig (botId, category, key, val, description, type, options, subkeys, parent_key, system) VALUES "
 
     if isinstance(multi, dict):
-        local_args = tuple()
+        log.debug(f"Multiple [{len(multi)}] config categories provided.")
+        query = []
         for k, v in multi.items():
+            log.debug(
+                f"Generating query for category [{k}] containing [{len(multi[k])}] items..."
+            )
+            local_args = tuple()
+            q2 = q
             for z in v:
                 if z.get("type") == "bool":
                     z["val"] = (
@@ -281,9 +287,9 @@ def add_bot_config(
                     z["val"] = int(z["val"])
 
                 if len(local_args):
-                    q += ", "
+                    q2 += ", "
 
-                q += "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                q2 += "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
                 local_args += (
                     int(botId),
                     k,
@@ -311,8 +317,8 @@ def add_bot_config(
                     else "False",
                 )
 
-        q += ";"
-        query = (q, local_args)
+            q2 += ";"
+            query.append((q2, local_args))
     else:
         if dataType == "bool":
             val = val if isinstance(val, bool) else (val.lower() == "true")
@@ -350,6 +356,8 @@ def add_bot_config(
     return database.db_qry(
         query, con=con, cur=cur, commit=commit, closeAfter=closeAfter
     )
+
+    return None
 
 
 def add_default_bot_config(botId, con=None, cur=None):

--- a/redball/database.py
+++ b/redball/database.py
@@ -306,7 +306,8 @@ def build_tables(tables, logg=log):
         queries.append(
             """INSERT OR IGNORE INTO rb_botTypes (name, description, moduleName)
                 VALUES
-                ('game-threads', 'Game Threads', 'game_threads'),
+                ('game-threads', 'MLB Game Threads', 'game_threads'),
+                ('nfl-game-threads', 'NFL Game Threads', 'nfl_game_threads'),
                 ('mlb-data', 'MLB Data', 'mlb_data'),
                 ('comment-response', 'Comment Response', 'comment_response'),
                 ('placeholder', 'Placeholder', '_template')

--- a/redball/upgrade.py
+++ b/redball/upgrade.py
@@ -302,5 +302,5 @@ upgradeScripts = {
         "UPDATE rb_meta SET val='4', lastUpdate='{}' WHERE key='dbVersion';".format(
             time.time()
         ),
-    ]
+    ],
 }

--- a/redball/upgrade.py
+++ b/redball/upgrade.py
@@ -303,4 +303,17 @@ upgradeScripts = {
             time.time()
         ),
     ],
+    5: [
+        # Change display name of game thread bot type to include MLB
+        """UPDATE rb_botTypes SET description='MLB Game Threads' WHERE name='game-threads';""",
+        # Add NFL Game Threads bot type
+        """INSERT OR IGNORE INTO rb_botTypes (name, description, moduleName)
+            VALUES
+            ('nfl-game-threads', 'NFL Game Threads', 'nfl_game_threads')
+        ;""",
+        # Update DB version to 5
+        "UPDATE rb_meta SET val='5', lastUpdate='{}' WHERE key='dbVersion';".format(
+            time.time()
+        ),
+    ],
 }

--- a/redball/user.py
+++ b/redball/user.py
@@ -246,7 +246,7 @@ def check_privilege(userid, privilege, refresh=False, checkAll=True):
     # or user has rb_bot_1_rw and privilege = rb_bot_1_ro
     # return False if user does not have required privilege
     auth_type = config.get_sys_config(category="Web/Security", key="AUTH_TYPE")[0]["val"]
-    if auth_type != "form":
+    if auth_type in ["Basic", "None"]:
         return True
 
     if userid is None or privilege in ["", None]:

--- a/redball/user.py
+++ b/redball/user.py
@@ -245,6 +245,10 @@ def check_privilege(userid, privilege, refresh=False, checkAll=True):
     # e.g. if user has rb_bot_all_rw and privilege=rb_bot_1_rw
     # or user has rb_bot_1_rw and privilege = rb_bot_1_ro
     # return False if user does not have required privilege
+    auth_type = config.get_sys_config(category="Web/Security", key="AUTH_TYPE")[0]["val"]
+    if auth_type != "form":
+        return True
+
     if userid is None or privilege in ["", None]:
         return False
 

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b11"
+VERSION = "1.0-alpha_b12"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b22"
+VERSION = "1.0-alpha_b24"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b7"
+VERSION = "1.0-alpha_b9"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b24"
+VERSION = "1.0-alpha_b25"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b15"
+VERSION = "1.0-alpha_b16"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b13"
+VERSION = "1.0-alpha_b14"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b21"
+VERSION = "1.0-alpha_b22"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha"
+VERSION = "1.0-alpha_b3"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b20"
+VERSION = "1.0-alpha_b21"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "0.0.7"
+VERSION = "1.0-alpha"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b27"
+VERSION = "1.0"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b26"
+VERSION = "1.0-alpha_b27"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b9"
+VERSION = "1.0-alpha_b10"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b10"
+VERSION = "1.0-alpha_b11"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b19"
+VERSION = "1.0-alpha_b20"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b12"
+VERSION = "1.0-alpha_b13"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b16"
+VERSION = "1.0-alpha_b17"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b18"
+VERSION = "1.0-alpha_b19"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b3"
+VERSION = "1.0-alpha_b7"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b17"
+VERSION = "1.0-alpha_b18"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b14"
+VERSION = "1.0-alpha_b15"

--- a/redball/version.py
+++ b/redball/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.0-alpha_b25"
+VERSION = "1.0-alpha_b26"

--- a/redball/webserver.py
+++ b/redball/webserver.py
@@ -186,7 +186,7 @@ def restart_webServer():
 def check_auth(*args, **kwargs):
     webSettings = rbConfig.get_sys_config(category="Web/Security")
     auth_type = next(x["val"] for x in webSettings if x["key"] == "AUTH_TYPE")
-    if auth_type != "form":
+    if auth_type != "Form":
         return True
 
     log.debug("Checking authentication against session: {}".format(cherrypy.session.items()))

--- a/redball/webserver.py
+++ b/redball/webserver.py
@@ -184,6 +184,11 @@ def restart_webServer():
 
 
 def check_auth(*args, **kwargs):
+    webSettings = rbConfig.get_sys_config(category="Web/Security")
+    auth_type = next(x["val"] for x in webSettings if x["key"] == "AUTH_TYPE")
+    if auth_type != "form":
+        return True
+
     log.debug("Checking authentication against session: {}".format(cherrypy.session.items()))
     u = cherrypy.session.get("_cp_username")
     if u:

--- a/redball/webserver.py
+++ b/redball/webserver.py
@@ -502,23 +502,24 @@ class WebInterface(object):
                 if isinstance(newBot.id, str):
                     local_args.update({"errors": newBot.id, "errorcontainer_hide": ""})
                 else:
-                    redball.BOTS.update({str(newBot.id): newBot})
-                    # Grant rw access to the bot creator
-                    redball.LOGGED_IN_USERS[cherrypy.session.get("_cp_username")][
-                        "PRIVS"
-                    ].append("rb_bot_{}_rw".format(newBot.id))
-                    q = (
-                        "UPDATE rb_users SET privileges = ? WHERE userid=?;",
-                        (
-                            json.dumps(
-                                redball.LOGGED_IN_USERS[
-                                    cherrypy.session.get("_cp_username")
-                                ]["PRIVS"]
+                    if cherrypy.session.get("_cp_username") != "authOff":
+                        redball.BOTS.update({str(newBot.id): newBot})
+                        # Grant rw access to the bot creator
+                        redball.LOGGED_IN_USERS[cherrypy.session.get("_cp_username")][
+                            "PRIVS"
+                        ].append("rb_bot_{}_rw".format(newBot.id))
+                        q = (
+                            "UPDATE rb_users SET privileges = ? WHERE userid=?;",
+                            (
+                                json.dumps(
+                                    redball.LOGGED_IN_USERS[
+                                        cherrypy.session.get("_cp_username")
+                                    ]["PRIVS"]
+                                ),
+                                cherrypy.session.get("_cp_username"),
                             ),
-                            cherrypy.session.get("_cp_username"),
-                        ),
-                    )
-                    database.db_qry(q, commit=True, closeAfter=True)
+                        )
+                        database.db_qry(q, commit=True, closeAfter=True)
         elif kwargs.get("action") == "delete" and bot_id:
             if not user.check_privilege(
                 cherrypy.session.get("_cp_username"),

--- a/redball/webserver.py
+++ b/redball/webserver.py
@@ -1185,7 +1185,7 @@ class WebInterface(object):
                     reddit_appId=kwargs["redditAuth_redditAppId"],
                     reddit_appSecret=kwargs["redditAuth_redditAppSecret"],
                     reddit_scopes=kwargs["redditAuth_redditScopes"],
-                    reddit_refreshToken=kwargs.get("reddit_refreshToken", ""),
+                    reddit_refreshToken=kwargs.get("redditAuth_redditRefreshToken", ""),
                 )
                 if isinstance(result, str):
                     local_args.update({"errors": result, "errorcontainer_hide": ""})

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyOpenSSL
 mako
 pyprowl
 python-twitter
+nflapi

--- a/web/templates/base.mako
+++ b/web/templates/base.mako
@@ -1,9 +1,13 @@
 <% 
-	import cherrypy
-	import redball
-	from redball import user
-	if cherrypy.session.get("_cp_username") and cherrypy.session["_cp_username"] in redball.LOGGED_IN_USERS.keys():
-		user.refresh_user_privileges(cherrypy.session["_cp_username"])
+    import cherrypy
+    import redball
+    from redball import config, user
+    if cherrypy.session.get("_cp_username") and cherrypy.session["_cp_username"] in redball.LOGGED_IN_USERS.keys():
+        user.refresh_user_privileges(cherrypy.session["_cp_username"])
+    auth_type = config.get_sys_config(category="Web/Security", key="AUTH_TYPE")
+    wideOpen = auth_type[0]["val"] == "None"
+    if wideOpen:
+        cherrypy.session["_cp_username"] = "admin"
 %>
 <%page args="errors='', info='', errorcontainer_hide=' class=hide', infocontainer_hide=' class=hide'" />
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -92,13 +96,13 @@ $(window).resize(function() {
 <header role="banner">
 	<div id="loginstatus">
 		<div id="userbox">
-			${'{}<a href="/password" title="Change Password"><span class="ui-icon ui-icon-wrench"></span></a><a href="/logout"><span class="ui-icon ui-icon-locked" title="Logout"></span></a>'.format(cherrypy.session.get("_cp_username")) if cherrypy.session.get("_cp_username") else '<a href="/login"><span class="ui-icon ui-icon-locked"></span>Login</a>'}
+			${'' if wideOpen else '{}<a href="/password" title="Change Password"><span class="ui-icon ui-icon-wrench"></span></a><a href="/logout"><span class="ui-icon ui-icon-locked" title="Logout"></span></a>'.format(cherrypy.session.get("_cp_username")) if cherrypy.session.get("_cp_username") else '<a href="/login"><span class="ui-icon ui-icon-locked"></span>Login</a>'}
 		</div>
 	</div>
 	<div id="logo"><a href="/" class="logo"><img src="/img/redball.png" height="40" width="40" style="vertical-align:middle"> ${self.siteHeader()}</a></div>
 	<div id="menu">
 		<ul class="menu">
-			% if cherrypy.session.get("_cp_username"):
+			% if cherrypy.session.get("_cp_username") or wideOpen == True:
 				% if 'Bot' in title and 'System Configuration' not in title:
 				<a href="/"><li class="active">Bots</li></a>
 				% else:

--- a/web/templates/base.mako
+++ b/web/templates/base.mako
@@ -6,8 +6,11 @@
         user.refresh_user_privileges(cherrypy.session["_cp_username"])
     auth_type = config.get_sys_config(category="Web/Security", key="AUTH_TYPE")
     wideOpen = auth_type[0]["val"] == "None"
+    basicAuth = auth_type[0]["val"] == "Basic"
     if wideOpen:
-        cherrypy.session["_cp_username"] = "admin"
+        cherrypy.session["_cp_username"] = "authOff"
+    elif basicAuth:
+        cherrypy.session["_cp_username"] = "basicAuth"
 %>
 <%page args="errors='', info='', errorcontainer_hide=' class=hide', infocontainer_hide=' class=hide'" />
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -96,13 +99,13 @@ $(window).resize(function() {
 <header role="banner">
 	<div id="loginstatus">
 		<div id="userbox">
-			${'' if wideOpen else '{}<a href="/password" title="Change Password"><span class="ui-icon ui-icon-wrench"></span></a><a href="/logout"><span class="ui-icon ui-icon-locked" title="Logout"></span></a>'.format(cherrypy.session.get("_cp_username")) if cherrypy.session.get("_cp_username") else '<a href="/login"><span class="ui-icon ui-icon-locked"></span>Login</a>'}
+			${'' if wideOpen or basicAuth else '{}<a href="/password" title="Change Password"><span class="ui-icon ui-icon-wrench"></span></a><a href="/logout"><span class="ui-icon ui-icon-locked" title="Logout"></span></a>'.format(cherrypy.session.get("_cp_username")) if cherrypy.session.get("_cp_username") else '<a href="/login"><span class="ui-icon ui-icon-locked"></span>Login</a>'}
 		</div>
 	</div>
 	<div id="logo"><a href="/" class="logo"><img src="/img/redball.png" height="40" width="40" style="vertical-align:middle"> ${self.siteHeader()}</a></div>
 	<div id="menu">
 		<ul class="menu">
-			% if cherrypy.session.get("_cp_username") or wideOpen == True:
+			% if cherrypy.session.get("_cp_username"):
 				% if 'Bot' in title and 'System Configuration' not in title:
 				<a href="/"><li class="active">Bots</li></a>
 				% else:


### PR DESCRIPTION
### Platform
FIX: Web interface inaccessible when AUTH_TYPE=None
FIX: Basic and None authentication options were not providing access to bots (no user-specific privileges will be honored for either of these options now).
FIX: Error when creating bot with AUTH_TYPE=None (see #13 for other known issues)
FIX: Bot config import fails for big config file
FIX: Refresh token not saved when creating a new reddit authorization
ENH: Game Threads bot label changed to MLB Game Threads
NEW: NFL Game Thread Bot (v1.0-alpha)
VER: 1.0
DBVER: 5

### MLB Game Threads
FIX: Errors in gumbo data patch process
FIX: Comment thread crashing when isScoringPlay is missing from data
FIX: Off thread sometimes unstickied prematurely
FIX: Comment body sometimes lists wrong team as leading
FIX: Scoring play list missing from game/post threads
FIX: Unwanted comments for other team's plays
FIX: Line score showed 0 for new inning earlier than MLB does
FIX: Hide weather conditions if only dummy data is published
FIX: Gameday thread update loop never ends if game gets postponed before game thread is posted and UPDATE_UNTIL="Game thread is posted"
FIX: GameDay and Game threads get posted when bot is restarted after game is postponed
FIX: Error getting bot state when gameday/game threads are skipped
FIX: DH Game 2 game thread does not post
FIX: Straight DH Game 2 shows wrong game date/time
FIX: Game thread update process crashes for DH G2 before G1 is final
FIX: DH Game 2 fails to match DH Game 1 when home/away teams flip
FIX: DH Game 2 using stale status for Game 1
FIX: Query error in check if all postgame threads are submitted (in order to skip gameday thread)
FIX: Bot thought season was suspended if restarted after all games ended
FIX: Don't default pitch count to 0-0 in comment body
ENH: Added custom date format and home/road win/loss and exception prefix settings for for thread titles
ENH: Wait 5 minutes after game 1 is final before posting game thread for straight DH game 2, to hopefully have updated records for thread title
ENH: Include game status in gameday thread
ENH: List runner and matchup info in game threads
ENH: Add locks to prevent multiple threads from updating data cache at the same time
ENH: Logging improvements
REM: Removed table holding game ids for game thread bots -- was not being used and was throwing an error for rescheduled games
INT: Better naming of scheduled tasks
VER: 1.0

### NFL Game Threads
VER: 1.0-alpha